### PR TITLE
Validate configuration + Tests improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,18 +5,7 @@ on:
   pull_request:
     branches: [ "main" ]
 jobs:
-  tests-monitor:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-      - run: npm install
-        working-directory: ./monitor
-      - run: node --test .
-        working-directory: ./monitor
-  tests-analytics:
+  tests:
     runs-on: ubuntu-latest
     services:
       postgresql:
@@ -34,14 +23,15 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
-      - run: npm install
+      - run: npm ci
+        working-directory: ./monitor
+      - run: npm ci
         working-directory: ./analytics
       - run: psql -d postgresql://lambda@localhost/poduptime -f deployment/database/schema.sql
         working-directory: ./analytics
         env:
           PGPASSWORD: secret
-      - run: node --test .
-        working-directory: ./analytics
+      - run: npm run test
         env:
           PGDATABASE: poduptime
           PGUSER: lambda

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,5 @@ COPY conf           conf
 COPY analytics      analytics
 COPY monitor        monitor
 COPY website        website
+COPY conf_test.js   .*
 COPY package*.json  ./

--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ The command also also starts a sidecar container with PostgreSQL. This configura
 
 Both the `monitor` and `analytics` components include automated tests. These tests run automatically on each pull request (PR) and can also be run manually from within the development container.
 
-To run the tests from inside each application folder, use the following commands:
+To run the tests use the following commands:
 
 ```shell
-node --test
+npm run test
 ```
 
 If you prefer to run the tests in watch mode, allowing them to re-run automatically after each code change, use:
 
 ```shell
-node --test --watch .
+npm run test-watch
 ```
 
 ### Running website

--- a/analytics/functions/aggregate-minutely/handler_test.js
+++ b/analytics/functions/aggregate-minutely/handler_test.js
@@ -19,7 +19,7 @@ const expectedCalls = flattenDeep(config.regions.map((region) => {
     );
 }));
 
-describe('aggregateMinutely', () => {
+describe('analytics - aggregateMinutely', () => {
 
     const sqs = use('sqs');
 

--- a/analytics/functions/aggregate-worker/handler_test.js
+++ b/analytics/functions/aggregate-worker/handler_test.js
@@ -9,7 +9,7 @@ import { formatISO, startOfMinute, subMinutes, eachMinuteOfInterval } from 'date
 const { randomUUID } = await import('node:crypto');
 import { use } from "../../common/fixtures.js";
 
-describe('aggregateWorker', () => {
+describe('analytics - aggregateWorker', () => {
 
     const db = use('db');
     const s3 = use('s3');

--- a/analytics/functions/archive-database/handler_test.js
+++ b/analytics/functions/archive-database/handler_test.js
@@ -7,7 +7,7 @@ import { queryOne } from "../../common/database.js";
 const { randomUUID } = await import('node:crypto');
 import { use } from "../../common/fixtures.js";
 
-describe('archiveDatabase', () => {
+describe('analytics - archiveDatabase', () => {
 
     use('db');
 

--- a/analytics/functions/archive-raw/handler_test.js
+++ b/analytics/functions/archive-raw/handler_test.js
@@ -6,7 +6,7 @@ import { formatISO, format } from 'date-fns';
 import { throwsAsync } from '../../common/assert.js'
 import { use } from "../../common/fixtures.js";
 
-describe('archiveRaw', () => {
+describe('analytics - archiveRaw', () => {
 
     const s3 = use('s3');
 

--- a/analytics/functions/cleanup-database/handler_test.js
+++ b/analytics/functions/cleanup-database/handler_test.js
@@ -6,7 +6,7 @@ import { query } from "../../common/database.js";
 const { randomUUID } = await import('node:crypto');
 import { use } from "../../common/fixtures.js";
 
-describe('cleanupDatabase', () => {
+describe('analytics - cleanupDatabase', () => {
 
     const db = use('db');
 

--- a/conf_test.js
+++ b/conf_test.js
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import prod from "./conf/config_prod.js";
+import nonprod from "./conf/config_nonprod.js";
+
+describe('config', () => {
+
+    const envs = [{ name: "prod", config: prod }, { name: "nonprod", config: nonprod }]
+
+    for (const env of envs) {
+
+        describe(`for environment ${env.name}`, () => {
+
+            const config = env.config;
+
+            it(`regions should be valid`, () => {
+
+                assert.ok(config.regions, "Regions must be defined");
+                assert.ok(!!config.regions.find((r) => r.id === "global"), "Global must be defined");
+                assert.ok(config.regions.length > 1, "At least another region");
+            });
+
+            it(`endpoints should be valid`, () => {
+
+                assert.ok(config.endpoints, "Endpoints must be defined");
+                assert.ok(config.endpoints.length > 0, "At least one endpoint");
+            });
+
+            for (const endpoint of config.endpoints) {
+
+                it(`endpoint ${endpoint.id} should be valid`, () => {
+
+                    assert.ok(endpoint.id, "An id is defined");
+                    assert.ok(endpoint.label, "A label is defined");
+                    assert.ok(endpoint.website_url, "A website_url is defined");
+                    assert.ok(endpoint.services, "Services are defined");
+                });
+
+                describe(`for endpoint ${endpoint.id}`, () => {
+
+                    for (const service of endpoint.services) {
+
+                        it(`service ${service.type} should be valid`, () => {
+
+                            assert.ok(service.type, "Service type is defined");
+                            assert.ok(service.url, "Service url is defined");
+
+                            if ("prefix" === service.type) {
+                                assert.ok(service.expected_url, "Expected url is defined");
+                            }
+                        });
+                    }
+                });
+            }
+        });
+    }
+});

--- a/conf_test.js
+++ b/conf_test.js
@@ -4,6 +4,14 @@ import assert from 'node:assert/strict';
 import prod from "./conf/config_prod.js";
 import nonprod from "./conf/config_nonprod.js";
 
+const assertValidUrl = (url, message) => {
+    try {
+        assert.ok(new URL(url), message);
+    } catch (e) {
+        assert.ok(false, message);
+    }
+}
+
 describe('config', () => {
 
     const envs = [{ name: "prod", config: prod }, { name: "nonprod", config: nonprod }]
@@ -33,8 +41,8 @@ describe('config', () => {
 
                     assert.ok(endpoint.id, "An id is defined");
                     assert.ok(endpoint.label, "A label is defined");
-                    assert.ok(endpoint.website_url, "A website_url is defined");
                     assert.ok(endpoint.services, "Services are defined");
+                    assertValidUrl(endpoint.website_url, "A website_url is defined and valid");
                 });
 
                 describe(`for endpoint ${endpoint.id}`, () => {
@@ -44,10 +52,11 @@ describe('config', () => {
                         it(`service ${service.type} should be valid`, () => {
 
                             assert.ok(service.type, "Service type is defined");
-                            assert.ok(service.url, "Service url is defined");
+                            assert.ok(["feed", "enclosure", "prefix"].includes(service.type), "Service type is supported");
 
+                            assertValidUrl(service.url, "Service url is defined and valid");
                             if ("prefix" === service.type) {
-                                assert.ok(service.expected_url, "Expected url is defined");
+                                assertValidUrl(service.expected_url, "Expected url is defined and valid");
                             }
                         });
                     }

--- a/monitor/functions/check-endpoint/handler_test.js
+++ b/monitor/functions/check-endpoint/handler_test.js
@@ -31,7 +31,7 @@ const assertEventBridgePayload = function (events, expected) {
     assert.equal(actual.type, expected.type);
 }
 
-describe('checkEndpoint', () => {
+describe('monitor - checkEndpoint', () => {
 
     const events = use('events');
 

--- a/monitor/functions/kickstart/handler_test.js
+++ b/monitor/functions/kickstart/handler_test.js
@@ -5,7 +5,7 @@ import { kickstart } from "./handler.js"
 import config from "../../conf/config.js";
 import { use } from "../../common/fixtures.js";
 
-describe('kickstart', () => {
+describe('monitor - kickstart', () => {
 
     const sqs = use('sqs');
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test",
+    "test-watch": "node --test --watch ."
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
This PR introduces validation for the global configuration and simplifies the test runner setup.

## Validate configuration

The configuration for both environments is getting validated to ensure that: 

- Mandatory properties are defined
- URLs are structurally valid
- Service types are known

## Test runner setup

Validating the configuration files created the need to have tests that are not scoped to a particular module. Because of this I refactored the test runner setup so:

- It runs from the root level and covers all modules
- It runs with the standard `npm test`/`npm run test` commands
- Each tests better declare the module they're part of