### PR TITLE
Start monitoring Audioboom and iVoox

### DIFF
--- a/conf/config_prod.js
+++ b/conf/config_prod.js
@@ -161,6 +161,36 @@ const endpoints = [
     ],
   },
   {
+    id: "audioboom",
+    label: "Audioboom",
+    website_url: "https://audioboom.com",
+    services: [
+      {
+        type: "enclosure",
+        url: "https://audioboom.com/posts/8391199.mp3?modified=1698395341&sid=5119220&source=rss",
+      },
+      {
+        type: "feed",
+        url: "https://audioboom.com/channels/5119220.rss",
+      },
+    ],
+  },
+  {
+    id: "ivoox",
+    label: "iVoox",
+    website_url: "https://podcasters.ivoox.com/",
+    services: [
+      {
+        type: "enclosure",
+        url: "https://www.ivoox.com/podcast-poduptime_fg_f12312823_filtro_1.xml",
+      },
+      {
+        type: "feed",
+        url: "https://www.ivoox.com/sample-episode_mf_118495604_feed_1.mp3?d=1698394289",
+      },
+    ],
+  },
+  {
     id: "podtrac",
     label: "Podtrac",
     website_url: "https://analytics.podtrac.com",

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -10,6 +10,16 @@ import Layout from '../layouts/Layout.astro'
 	</p>
 
 	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+		October 27th, 2023
+	</h2>
+
+	<ul class="mb-4 list-outside list-disc pl-4">
+		<li class="pb-3 [&>code]:underline">
+			We added the following services to our monitoring list: <code>Audioboom</code> and <code>iVoox</code>.
+		</li>
+	</ul>
+
+	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
 		October 26th, 2023
 	</h2>
 


### PR DESCRIPTION
This PR adds two new hosting platforms: Audioboom and iVoox. 

Audioboom: https://audioboom.com/channels/5119220-poduptime
iVoox: https://www.ivoox.com/podcast-poduptime_sq_f12312823_1.html

For both them we are monitoring the RSS feed and the RSS enclosure.

Closes #3, Closes #4