### PR TITLE
Feature: Recent issues - Analytics

### DIFF
--- a/analytics/deployment/database/schema.sql
+++ b/analytics/deployment/database/schema.sql
@@ -1,5 +1,5 @@
 --
--- Measurements table
+-- Measurements table, to store measurements that will be aggregated
 --
 
 CREATE TABLE measurements (
@@ -13,3 +13,18 @@ CREATE TABLE measurements (
 );
 
 CREATE INDEX measurements_timestamp_endpoint_idx ON measurements (timestamp, endpoint);
+
+--
+-- Raw Unavailable table, to store recent failures for troubleshooting purposes
+--
+
+CREATE TABLE unavailables (
+    id         UUID PRIMARY KEY,
+    timestamp  TIMESTAMP NOT NULL,
+    endpoint   TEXT NOT NULL,
+    type       TEXT NOT NULL,
+    region     TEXT NOT NULL,
+    details    TEXT NOT NULL
+);
+
+CREATE INDEX unavailables_timestamp_endpoint_idx ON unavailables (timestamp, endpoint);

--- a/analytics/functions/aggregate-minutely/handler_test.js
+++ b/analytics/functions/aggregate-minutely/handler_test.js
@@ -13,7 +13,8 @@ const expectedCalls = flattenDeep(config.regions.map((region) => {
         config.endpoints.map((endpoint) => {
             return [
                 { type: "detailed", region: region.id, endpoint: endpoint.id },
-                { type: "instant-endpoint", region: region.id, endpoint: endpoint.id }
+                { type: "instant-endpoint", region: region.id, endpoint: endpoint.id },
+                { type: "recent-issues", region: region.id, endpoint: endpoint.id },
             ];
         })
     );

--- a/analytics/functions/aggregate-worker/handler.js
+++ b/analytics/functions/aggregate-worker/handler.js
@@ -179,10 +179,7 @@ const aggreateRecentIssues = async function (aggregation) {
     await s3Client.send(new PutObjectCommand({
         Bucket: process.env.WEBSITE_BUCKET,
         Key: `api/recent-issues-${endpoint}-${region}.json`,
-        Body: JSON.stringify({
-            timestamp: formatISO(new Date()),
-            data: result
-        }),
+        Body: JSON.stringify(result),
         ContentType: "application/json"
     }));
 }

--- a/analytics/functions/aggregate-worker/handler.js
+++ b/analytics/functions/aggregate-worker/handler.js
@@ -155,6 +155,38 @@ const aggregateDetailed = async function (aggregation) {
     }));
 }
 
+const aggreateRecentIssues = async function (aggregation) {
+
+    const region = aggregation.region;
+    const endpoint = aggregation.endpoint;
+
+    let rows = "global" === region ?
+        (await query(`
+            SELECT details
+            FROM unavailables
+            WHERE endpoint = $1
+            ORDER BY timestamp DESC LIMIT 10
+        `, [endpoint])).rows :
+        (await query(`
+            SELECT details
+            FROM unavailables
+            WHERE endpoint = $1
+            AND region = $2 ORDER BY timestamp DESC LIMIT 10
+        `, [endpoint, region])).rows;
+
+    let result = rows.map((row) => JSON.parse(row.details));
+
+    await s3Client.send(new PutObjectCommand({
+        Bucket: process.env.WEBSITE_BUCKET,
+        Key: `api/recent-issues-${endpoint}-${region}.json`,
+        Body: JSON.stringify({
+            timestamp: formatISO(new Date()),
+            data: result
+        }),
+        ContentType: "application/json"
+    }));
+}
+
 export const aggregateWorker = async function (event, context) {
 
     const aggregation = JSON.parse(event.Records[0].body);
@@ -165,6 +197,8 @@ export const aggregateWorker = async function (event, context) {
         await aggregateDetailed(aggregation);
     } else if ("instant-endpoint" === aggregation.type) {
         await aggregateInstantEndpoint(aggregation);
+    } else if ("recent-issues" === aggregation.type) {
+        await aggreateRecentIssues(aggregation);
     } else {
         console.error("Unknown aggregation", event);
     }

--- a/analytics/functions/aggregate-worker/handler_test.js
+++ b/analytics/functions/aggregate-worker/handler_test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { aggregateWorker } from "./handler.js"
@@ -275,20 +275,11 @@ describe('analytics - aggregateWorker', () => {
             await aggregateWorker({ Records: [{ body: JSON.stringify({ type: "recent-issues", endpoint: "service", region: "global" }) }] });
 
             const s3calls = s3.calls(PutObjectCommand);
-
             assert.equal(s3calls.length, 1);
-
-            const expected = {
-                timestamp: /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/, // is an ISO 8601 timestamp
-                data: [
-                    { foo: 'bar1' },
-                    { foo: 'bar2' }
-                ]
-            };
-
-            const actual = JSON.parse(s3calls[0].args[0].input.Body);
-            assert.deepStrictEqual(actual.data, expected.data);
-            assert.match(actual.timestamp, expected.timestamp);
+            assert.deepStrictEqual(s3calls[0].args[0].input.Body, JSON.stringify([
+                { foo: 'bar1' },
+                { foo: 'bar2' }
+            ]));
             assert.deepStrictEqual(s3calls[0].args[0].input.Key, "api/recent-issues-service-global.json");
         });
 
@@ -297,19 +288,10 @@ describe('analytics - aggregateWorker', () => {
             await aggregateWorker({ Records: [{ body: JSON.stringify({ type: "recent-issues", endpoint: "service", region: "antartica-1" }) }] });
 
             const s3calls = s3.calls(PutObjectCommand);
-
             assert.equal(s3calls.length, 1);
-
-            const expected = {
-                timestamp: /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/, // is an ISO 8601 timestamp
-                data: [
-                    { foo: 'bar1' }
-                ]
-            };
-
-            const actual = JSON.parse(s3calls[0].args[0].input.Body);
-            assert.deepStrictEqual(actual.data, expected.data);
-            assert.match(actual.timestamp, expected.timestamp);
+            assert.deepStrictEqual(s3calls[0].args[0].input.Body, JSON.stringify([
+                { foo: 'bar1' }
+            ]));
             assert.deepStrictEqual(s3calls[0].args[0].input.Key, "api/recent-issues-service-antartica-1.json");
         });
 

--- a/analytics/functions/aggregate-worker/handler_test.js
+++ b/analytics/functions/aggregate-worker/handler_test.js
@@ -250,6 +250,83 @@ describe('analytics - aggregateWorker', () => {
         });
     });
 
+    describe('recent-issues', () => {
+
+        beforeEach(async () => {
+
+            const unavailables = [
+                { id: randomUUID(), timestamp: formatISO(new Date()), endpoint: "service", type: "feed", region: "antartica-1", details: JSON.stringify({ foo: 'bar1' }) },
+                { id: randomUUID(), timestamp: formatISO(new Date()), endpoint: "service", type: "feed", region: "antartica-2", details: JSON.stringify({ foo: 'bar2' }) }
+            ];
+
+            for (const unavailable of unavailables) {
+                await db.query(`
+                INSERT INTO unavailables (id, timestamp, endpoint, type, region, details)
+                VALUES ($1, $2, $3, $4, $5, $6)
+            `, [
+                    unavailable.id, unavailable.timestamp, unavailable.endpoint,
+                    unavailable.type, unavailable.region, unavailable.details
+                ]);
+            }
+        });
+
+        it('should run the query for global region and upload to S3', async (t) => {
+
+            await aggregateWorker({ Records: [{ body: JSON.stringify({ type: "recent-issues", endpoint: "service", region: "global" }) }] });
+
+            const s3calls = s3.calls(PutObjectCommand);
+
+            assert.equal(s3calls.length, 1);
+
+            const expected = {
+                timestamp: /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/, // is an ISO 8601 timestamp
+                data: [
+                    { foo: 'bar1' },
+                    { foo: 'bar2' }
+                ]
+            };
+
+            const actual = JSON.parse(s3calls[0].args[0].input.Body);
+            assert.deepStrictEqual(actual.data, expected.data);
+            assert.match(actual.timestamp, expected.timestamp);
+            assert.deepStrictEqual(s3calls[0].args[0].input.Key, "api/recent-issues-service-global.json");
+        });
+
+        it('should run the query for specific region and upload to S3', async (t) => {
+
+            await aggregateWorker({ Records: [{ body: JSON.stringify({ type: "recent-issues", endpoint: "service", region: "antartica-1" }) }] });
+
+            const s3calls = s3.calls(PutObjectCommand);
+
+            assert.equal(s3calls.length, 1);
+
+            const expected = {
+                timestamp: /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/, // is an ISO 8601 timestamp
+                data: [
+                    { foo: 'bar1' }
+                ]
+            };
+
+            const actual = JSON.parse(s3calls[0].args[0].input.Body);
+            assert.deepStrictEqual(actual.data, expected.data);
+            assert.match(actual.timestamp, expected.timestamp);
+            assert.deepStrictEqual(s3calls[0].args[0].input.Key, "api/recent-issues-service-antartica-1.json");
+        });
+
+        it('should throw on S3 errors', async (t) => {
+
+            s3.rejects('simulated error');
+
+            await throwsAsync(aggregateWorker({
+                Records: [{
+                    body: JSON.stringify({
+                        type: "recent-issues", region: "antartica", endpoint: "service"
+                    })
+                }]
+            }), null);
+        });
+    });
+
     describe('unknown', () => {
 
         it('should throw on unknown aggregation', async (t) => {

--- a/analytics/functions/archive-database/handler.js
+++ b/analytics/functions/archive-database/handler.js
@@ -22,5 +22,18 @@ export const archiveDatabase = async function (event, context) {
         result.type, result.region, result.available,
         result.duration
     ]);
+
+    if (result.available < 1) {
+        await query(`
+            INSERT INTO unavailables
+            (id, timestamp, endpoint, type, region, details)
+            VALUES
+            ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT DO NOTHING
+        `, [
+            result.id, result.timestamp, result.endpoint,
+            result.type, result.region, JSON.stringify(result)
+        ]);
+    }
 }
 

--- a/analytics/functions/archive-database/handler_test.js
+++ b/analytics/functions/archive-database/handler_test.js
@@ -7,31 +7,32 @@ import { queryOne } from "../../common/database.js";
 const { randomUUID } = await import('node:crypto');
 import { use } from "../../common/fixtures.js";
 
+const SAMPLE_EVENT = {
+    id: randomUUID(),
+    timestamp: formatISO(new Date()),
+    region: "antartica",
+    endpoint: "origin",
+    url: "https://poduptime.com",
+    type: "enclosure",
+    status: 200,
+    duration: 100,
+    headers: {
+        "content-type": "text/html; charset=utf-8",
+        "content-length": "218",
+    },
+    traversal: [
+        "https://poduptime.com",
+        "https://poduptime.com/error"
+    ]
+}
+
 describe('analytics - archiveDatabase', () => {
 
     use('db');
 
     it('should archive successful measurement', async () => {
 
-        const event = {
-            id: randomUUID(),
-            timestamp: formatISO(new Date()),
-            region: "antartica",
-            endpoint: "origin",
-            url: "https://poduptime.com",
-            type: "enclosure",
-            status: 200,
-            duration: 100,
-            headers: {
-                "content-type": "text/html; charset=utf-8",
-                "content-length": "218",
-            },
-            traversal: [
-                "https://poduptime.com",
-                "https://poduptime.com/error"
-            ],
-            available: 1
-        };
+        const event = { ...SAMPLE_EVENT, available: 1 };
 
         await archiveDatabase({ detail: event });
 
@@ -52,25 +53,7 @@ describe('analytics - archiveDatabase', () => {
 
     it('should archive unsuccessful measurement', async () => {
 
-        const event = {
-            id: randomUUID(),
-            timestamp: formatISO(new Date()),
-            region: "antartica",
-            endpoint: "origin",
-            url: "https://poduptime.com",
-            type: "enclosure",
-            status: 500,
-            duration: 100,
-            headers: {
-                "content-type": "text/html; charset=utf-8",
-                "content-length": "218",
-            },
-            traversal: [
-                "https://poduptime.com",
-                "https://poduptime.com/error"
-            ],
-            available: 0
-        };
+        const event = { ...SAMPLE_EVENT, available: 0 };
 
         await archiveDatabase({ detail: event });
 

--- a/analytics/functions/archive-database/handler_test.js
+++ b/analytics/functions/archive-database/handler_test.js
@@ -11,23 +11,89 @@ describe('analytics - archiveDatabase', () => {
 
     use('db');
 
-    it('should archive measurement', async () => {
+    it('should archive successful measurement', async () => {
 
         const event = {
             id: randomUUID(),
-            endpoint: "origin",
-            type: "enclosure",
-            region: "antartica",
             timestamp: formatISO(new Date()),
-            available: 1,
-            duration: 1.5
+            region: "antartica",
+            endpoint: "origin",
+            url: "https://poduptime.com",
+            type: "enclosure",
+            status: 200,
+            duration: 100,
+            headers: {
+                "content-type": "text/html; charset=utf-8",
+                "content-length": "218",
+            },
+            traversal: [
+                "https://poduptime.com",
+                "https://poduptime.com/error"
+            ],
+            available: 1
         };
 
         await archiveDatabase({ detail: event });
 
-        const row = await queryOne("SELECT * FROM measurements WHERE id = $1", [event.id]);
+        const measurement = await queryOne("SELECT * FROM measurements WHERE id = $1", [event.id]);
+        assert.deepStrictEqual(measurement, {
+            id: event.id,
+            endpoint: event.endpoint,
+            type: event.type,
+            region: event.region,
+            timestamp: event.timestamp,
+            available: event.available,
+            duration: event.duration
+        });
 
-        assert.deepStrictEqual(row, event);
+        const unavailable = await queryOne("SELECT * FROM unavailables WHERE id = $1", [event.id]);
+        assert.equal(unavailable, null);
+    });
+
+    it('should archive unsuccessful measurement', async () => {
+
+        const event = {
+            id: randomUUID(),
+            timestamp: formatISO(new Date()),
+            region: "antartica",
+            endpoint: "origin",
+            url: "https://poduptime.com",
+            type: "enclosure",
+            status: 500,
+            duration: 100,
+            headers: {
+                "content-type": "text/html; charset=utf-8",
+                "content-length": "218",
+            },
+            traversal: [
+                "https://poduptime.com",
+                "https://poduptime.com/error"
+            ],
+            available: 0
+        };
+
+        await archiveDatabase({ detail: event });
+
+        const measurement = await queryOne("SELECT * FROM measurements WHERE id = $1", [event.id]);
+        assert.deepStrictEqual(measurement, {
+            id: event.id,
+            endpoint: event.endpoint,
+            type: event.type,
+            region: event.region,
+            timestamp: event.timestamp,
+            available: event.available,
+            duration: event.duration
+        });
+
+        const unavailable = await queryOne("SELECT * FROM unavailables WHERE id = $1", [event.id]);
+        assert.deepStrictEqual(unavailable, {
+            id: event.id,
+            endpoint: event.endpoint,
+            type: event.type,
+            region: event.region,
+            timestamp: event.timestamp,
+            details: JSON.stringify(event)
+        });
     });
 
     it('should throw on database errors', async (t) => {

--- a/analytics/functions/cleanup-database/handler.js
+++ b/analytics/functions/cleanup-database/handler.js
@@ -1,13 +1,20 @@
 import { query } from "../../common/database.js";
 
+/*
+ * We want to be able to re-aggregate data up to 30 days ago
+ * so we add one extra day of tolerance
+ */
+const RETENTION_DAYS = 31;
+
 export const cleanupDatabase = async function (event, context) {
 
-    /**
-     * We want to be able to re-aggregate data up to 30 days ago
-     * so we add one extra day of tolerance
-     */
     await query(`
         DELETE FROM measurements
-        WHERE timestamp < CURRENT_TIMESTAMP - interval '31 days';
+        WHERE timestamp < CURRENT_TIMESTAMP - interval '${RETENTION_DAYS} days';
+    `);
+
+    await query(`
+        DELETE FROM unavailables
+        WHERE timestamp < CURRENT_TIMESTAMP - interval '${RETENTION_DAYS} days';
     `);
 }

--- a/analytics/functions/cleanup-database/handler_test.js
+++ b/analytics/functions/cleanup-database/handler_test.js
@@ -41,4 +41,35 @@ describe('analytics - cleanupDatabase', () => {
         assert.deepStrictEqual(rows, [measurements[0]]);
     });
 
+    it('should delete old unavailables', async () => {
+
+        const unavailables = [
+            {
+                id: randomUUID(), timestamp: formatISO(new Date()), endpoint: "service",
+                type: "enclosure", region: "antartica-1", details: '{}'
+            },
+            {
+                id: randomUUID(), timestamp: formatISO(subDays(new Date(), 32)), endpoint: "service",
+                type: "enclosure", region: "antartica-1", details: '{}'
+            },
+        ];
+
+        for (const unavailable of unavailables) {
+            await db.query(`
+            INSERT INTO unavailables (id, timestamp, endpoint, type, region, details)
+            VALUES ($1, $2, $3, $4, $5, $6)
+        `, [
+                unavailable.id, unavailable.timestamp, unavailable.endpoint,
+                unavailable.type, unavailable.region, unavailable.details
+            ]);
+        }
+
+        await cleanupDatabase();
+
+        const rows = (await query("SELECT * FROM unavailables")).rows;
+
+        assert.equal(rows.length, 1);
+        assert.deepStrictEqual(rows, [unavailables[0]]);
+    });
+
 });


### PR DESCRIPTION
The first step to provide #2 is to store and aggregate unsuccessful measurements so they can be consumed by the website. 

## Store

I created a dedicated table `unavailables` to store detailed information for every unsuccessful measurement, since I didn't want to clutter the main `measurements` table with the debug informations for every item. This table is indexed by timestamp and endpoint like the main table so aggregation and data retention operations are performant enough.

## Retention

Items in the `unavailables` table are kept for the same ~30 days interval we use for the `measurements` table.

## Aggregation

An API under the route `api/recent-issues-${endpoint}-${region}.json` is exposed to the website. The response contains the most recent 10 failures for the given endpoint and region. The global version contains measurements from all regions.

## Other considerations

Some repetitive patterns are starting to emerge, and we should use batching to post messages to SQS to increase efficiency. Also we think it may be useful to change the format of APIs to include the timestamp when the aggregation was performed so the UI can show a "Last Updated" label. These are going to be addressed in separate PRs.