### PR TITLE
Increase timeout for minutely aggregation lambda

### DIFF
--- a/analytics/serverless.yml
+++ b/analytics/serverless.yml
@@ -138,6 +138,7 @@ functions:
   aggregateMinutely:
     name: ${self:custom.appPrefix}-aggregateMinutely
     handler: functions/aggregate-minutely/handler.aggregateMinutely
+    timeout: 55
     environment:
       AGGREGATE_QUEUE_URL:
         Fn::GetAtt:


### PR DESCRIPTION
With the new `recent-issues` aggregations to schedule, the function sometimes hits the default timeout. Until https://github.com/spreaker/poduptime/issues/9 won't be fixed, we'll need to have an higher timeout.