### PR TITLE
Added recent issues UI

### DIFF
--- a/website/.prettierrc
+++ b/website/.prettierrc
@@ -1,9 +1,9 @@
 {
-  "useTabs": true,
-  "singleQuote": true,
-  "trailingComma": "none",
-  "semi": false,
-  "printWidth": 100,
-  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
-  "pluginSearchDirs": false
+	"useTabs": false,
+	"singleQuote": true,
+	"trailingComma": "none",
+	"semi": false,
+	"printWidth": 100,
+	"plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
+	"pluginSearchDirs": false
 }

--- a/website/src/components/Status.astro
+++ b/website/src/components/Status.astro
@@ -1,34 +1,34 @@
 ---
 interface Props {
-	type: 'UP' | 'DOWN' | 'PARTIAL' | 'UNKNOWN' | 'LOADING'
+  type: 'UP' | 'DOWN' | 'PARTIAL' | 'UNKNOWN' | 'LOADING'
 }
 
 const { type } = Astro.props
 
 const text = {
-	UP: 'UP',
-	DOWN: 'DOWN',
-	PARTIAL: 'PARTIAL',
-	UNKNOWN: 'UNKNOWN',
-	LOADING: '...'
+  UP: 'UP',
+  DOWN: 'DOWN',
+  PARTIAL: 'PARTIAL',
+  UNKNOWN: 'UNKNOWN',
+  LOADING: '...'
 }
 
 const base = [
-	'rounded border-2',
-	'px-2',
-	'py-1',
-	'text-center',
-	'text-xs',
-	'font-bold',
-	'inline-block'
+  'rounded border-2',
+  'px-2',
+  'py-1',
+  'text-center',
+  'text-xs',
+  'font-bold',
+  'inline-block'
 ]
 
 const status = {
-	UP: ['text-lime-300', 'border-lime-600', 'hover:border-lime-300'],
-	DOWN: ['text-red-300', 'border-red-600', 'hover:border-red-300'],
-	PARTIAL: ['text-yellow-300', 'border-yellow-600', 'hover:border-yellow-300'],
-	UNKNOWN: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300'],
-	LOADING: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300']
+  UP: ['text-lime-300', 'border-lime-600', 'hover:border-lime-300'],
+  DOWN: ['text-red-300', 'border-red-600', 'hover:border-red-300'],
+  PARTIAL: ['text-yellow-300', 'border-yellow-600', 'hover:border-yellow-300'],
+  UNKNOWN: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300'],
+  LOADING: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300']
 }
 ---
 

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -1,91 +1,91 @@
 ---
 interface Props {
-	title: string
-	headerLink?: string
+  title: string
+  headerLink?: string
 }
 
 const { title, headerLink } = Astro.props
 
-const canonicalURL = Astro.site ? new URL(Astro.url.pathname, Astro.site) : null;
+const canonicalURL = Astro.site ? new URL(Astro.url.pathname, Astro.site) : null
 ---
 
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="description" content="PodUptime. Uptime monitoring for the podcast industry." />
-		<meta name="keywords" content="Podcast, Uptime, Monitoring, Hosting, Tracking Prefix" />
-		<meta name="viewport" content="width=device-width" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="PodUptime. Uptime monitoring for the podcast industry." />
+    <meta name="keywords" content="Podcast, Uptime, Monitoring, Hosting, Tracking Prefix" />
+    <meta name="viewport" content="width=device-width" />
 
-		<meta property="og:title" content={title} />
-		<meta
-			property="og:description"
-			content="PodUptime. Uptime monitoring for the podcast industry."
-		/>
-		<meta property="og:image" content="/og-image.jpg" />
+    <meta property="og:title" content={title} />
+    <meta
+      property="og:description"
+      content="PodUptime. Uptime monitoring for the podcast industry."
+    />
+    <meta property="og:image" content="/og-image.jpg" />
 
-		<link rel="sitemap" href="/sitemap-index.xml" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		{canonicalURL &&<link rel="canonical" href={canonicalURL} />}
-		<title>{title}</title>
-	</head>
+    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    {canonicalURL && <link rel="canonical" href={canonicalURL} />}
+    <title>{title}</title>
+  </head>
 
-	<body class="min-h-screen w-full bg-gradient-to-br from-zinc-950 via-pink-950 to-blue-950">
-		<main class="m-auto max-w-3xl p-4 text-pink-200">
-			<div class="group/neon relative mt-4">
-				<div
-					class="absolute -inset-1 rounded-lg bg-gradient-to-tr from-pink-500 via-pink-100 to-blue-900 opacity-25 blur transition duration-1000 group-hover/neon:opacity-100 group-hover/neon:duration-200"
-				>
-				</div>
-				<div class="w-full rounded-xl bg-gradient-to-tr from-pink-400 via-red-500 to-blue-900 p-1">
-					<a href={headerLink}>
-						<img
-							class="relative h-[300px] w-full rounded-t-lg object-cover object-top pb-1 sm:h-[420px]"
-							src="/logo.jpg"
-							alt="PodUptime, podcast uptime monitoring for the podcast industry"
-						/>
-					</a>
-					<div
-						class="items-top relative flex justify-start space-x-6 rounded-lg bg-white ring-1 ring-gray-900/5"
-					>
-						<div
-							class="h-full w-full rounded-b-lg bg-gradient-to-br from-zinc-950 via-pink-950 to-blue-950 p-4 sm:p-8"
-						>
-							<slot />
-						</div>
-					</div>
-				</div>
-			</div>
-		</main>
-		<div class="m-auto flex max-w-3xl p-4 text-xs font-thin text-pink-200">
-			<div class="flex-grow">
-				Copyright 2023 &nbsp;|&nbsp;
-				<a
-					class="font-normal underline"
-					rel="noopener"
-					target="_blank"
-					href="https://www.spreaker.com/">Spreaker</a
-				>
-			</div>
-			<div>
-				<a class="font-normal underline" href="/about/">About</a>
-				 &nbsp;|&nbsp;
-				<a class="font-normal underline" href="/changelog/">Changelog</a>
-				 &nbsp;|&nbsp;
-				<a
-					class="font-normal underline"
-					rel="noopener"
-					target="_blank"
-					href="https://www.spreaker.com/privacy">Privacy</a
-				>
-				 &nbsp;|&nbsp;
-				<a
-					class="font-normal underline"
-					rel="noopener"
-					target="_blank"
-					href="https://www.spreaker.com/terms">Terms</a
-				>
-			</div>
-		</div>
-	</body>
+  <body class="min-h-screen w-full bg-gradient-to-br from-zinc-950 via-pink-950 to-blue-950">
+    <main class="m-auto max-w-3xl p-4 text-pink-200">
+      <div class="group/neon relative mt-4">
+        <div
+          class="absolute -inset-1 rounded-lg bg-gradient-to-tr from-pink-500 via-pink-100 to-blue-900 opacity-25 blur transition duration-1000 group-hover/neon:opacity-100 group-hover/neon:duration-200"
+        >
+        </div>
+        <div class="w-full rounded-xl bg-gradient-to-tr from-pink-400 via-red-500 to-blue-900 p-1">
+          <a href={headerLink}>
+            <img
+              class="relative h-[300px] w-full rounded-t-lg object-cover object-top pb-1 sm:h-[420px]"
+              src="/logo.jpg"
+              alt="PodUptime, podcast uptime monitoring for the podcast industry"
+            />
+          </a>
+          <div
+            class="items-top relative flex justify-start space-x-6 rounded-lg bg-white ring-1 ring-gray-900/5"
+          >
+            <div
+              class="h-full w-full rounded-b-lg bg-gradient-to-br from-zinc-950 via-pink-950 to-blue-950 p-4 sm:p-8"
+            >
+              <slot />
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+    <div class="m-auto flex max-w-3xl p-4 text-xs font-thin text-pink-200">
+      <div class="flex-grow">
+        Copyright 2023 &nbsp;|&nbsp;
+        <a
+          class="font-normal underline"
+          rel="noopener"
+          target="_blank"
+          href="https://www.spreaker.com/">Spreaker</a
+        >
+      </div>
+      <div>
+        <a class="font-normal underline" href="/about/">About</a>
+         &nbsp;|&nbsp;
+        <a class="font-normal underline" href="/changelog/">Changelog</a>
+         &nbsp;|&nbsp;
+        <a
+          class="font-normal underline"
+          rel="noopener"
+          target="_blank"
+          href="https://www.spreaker.com/privacy">Privacy</a
+        >
+         &nbsp;|&nbsp;
+        <a
+          class="font-normal underline"
+          rel="noopener"
+          target="_blank"
+          href="https://www.spreaker.com/terms">Terms</a
+        >
+      </div>
+    </div>
+  </body>
 </html>

--- a/website/src/lib/Api.ts
+++ b/website/src/lib/Api.ts
@@ -2,64 +2,64 @@ import { Detail, Instant, Issue, ServiceInstant } from '../types'
 import { API_BASE_URL } from './Constants'
 
 export async function fetchInstantData(region: string): Promise<Instant[]> {
-	return await fetch(`${API_BASE_URL}/api/instant-${region}.json`)
-		.then((response) => response.json() as Promise<Instant[]>)
-		.then((data) => {
-			return data
-		})
-		.catch(() => {
-			return []
-		})
+  return await fetch(`${API_BASE_URL}/api/instant-${region}.json`)
+    .then((response) => response.json() as Promise<Instant[]>)
+    .then((data) => {
+      return data
+    })
+    .catch(() => {
+      return []
+    })
 }
 
 export async function fetchServiceInstantsData(
-	endpoint: string,
-	region: string
+  endpoint: string,
+  region: string
 ): Promise<ServiceInstant[]> {
-	return await fetch(`${API_BASE_URL}/api/instant-${endpoint}-${region}.json`)
-		.then((response) => response.json() as Promise<ServiceInstant[]>)
-		.then((data) => {
-			return data
-		})
-		.catch(() => {
-			return []
-		})
+  return await fetch(`${API_BASE_URL}/api/instant-${endpoint}-${region}.json`)
+    .then((response) => response.json() as Promise<ServiceInstant[]>)
+    .then((data) => {
+      return data
+    })
+    .catch(() => {
+      return []
+    })
 }
 
 export async function fetchDetailedData(endpoint: string, region: string): Promise<Detail[]> {
-	return await fetch(`${API_BASE_URL}/api/detailed-${endpoint}-${region}.json`)
-		.then((response) => response.json() as Promise<Detail[]>)
-		.then((data) => {
-			return data
-		})
-		.catch(() => {
-			return []
-		})
+  return await fetch(`${API_BASE_URL}/api/detailed-${endpoint}-${region}.json`)
+    .then((response) => response.json() as Promise<Detail[]>)
+    .then((data) => {
+      return data
+    })
+    .catch(() => {
+      return []
+    })
 }
 
 export async function fetchRecentIssues(endpoint: string, region: string): Promise<Issue[]> {
-	return await fetch(`${API_BASE_URL}/api/recent-issues-${endpoint}-${region}.json`)
-		.then((response) => response.json() as Promise<Issue[]>)
-		.then((data) => {
-			return data
-		})
-		.catch(() => {
-			return []
-		})
+  return await fetch(`${API_BASE_URL}/api/recent-issues-${endpoint}-${region}.json`)
+    .then((response) => response.json() as Promise<Issue[]>)
+    .then((data) => {
+      return data
+    })
+    .catch(() => {
+      return []
+    })
 }
 
 export async function fetchDetailedAndServiceInstantsAndRecentIssuesData(
-	endpoint: string,
-	region: string
+  endpoint: string,
+  region: string
 ): Promise<{
-	detailed: Detail[]
-	instants: ServiceInstant[]
-	issues: Issue[]
+  detailed: Detail[]
+  instants: ServiceInstant[]
+  issues: Issue[]
 }> {
-	const [detailed, instants, issues] = await Promise.all([
-		fetchDetailedData(endpoint, region),
-		fetchServiceInstantsData(endpoint, region),
-		fetchRecentIssues(endpoint, region)
-	])
-	return { detailed, instants, issues }
+  const [detailed, instants, issues] = await Promise.all([
+    fetchDetailedData(endpoint, region),
+    fetchServiceInstantsData(endpoint, region),
+    fetchRecentIssues(endpoint, region)
+  ])
+  return { detailed, instants, issues }
 }

--- a/website/src/lib/Api.ts
+++ b/website/src/lib/Api.ts
@@ -1,4 +1,4 @@
-import { Detail, Instant, ServiceInstant } from '../types'
+import { Detail, Instant, Issue, ServiceInstant } from '../types'
 import { API_BASE_URL } from './Constants'
 
 export async function fetchInstantData(region: string): Promise<Instant[]> {
@@ -37,16 +37,29 @@ export async function fetchDetailedData(endpoint: string, region: string): Promi
 		})
 }
 
-export async function fetchDetailedAndServiceInstantsData(
+export async function fetchRecentIssues(endpoint: string, region: string): Promise<Issue[]> {
+	return await fetch(`${API_BASE_URL}/api/recent-issues-${endpoint}-${region}.json`)
+		.then((response) => response.json() as Promise<Issue[]>)
+		.then((data) => {
+			return data
+		})
+		.catch(() => {
+			return []
+		})
+}
+
+export async function fetchDetailedAndServiceInstantsAndRecentIssuesData(
 	endpoint: string,
 	region: string
 ): Promise<{
 	detailed: Detail[]
 	instants: ServiceInstant[]
+	issues: Issue[]
 }> {
-	const [detailed, instants] = await Promise.all([
+	const [detailed, instants, issues] = await Promise.all([
 		fetchDetailedData(endpoint, region),
-		fetchServiceInstantsData(endpoint, region)
+		fetchServiceInstantsData(endpoint, region),
+		fetchRecentIssues(endpoint, region)
 	])
-	return { detailed, instants }
+	return { detailed, instants, issues }
 }

--- a/website/src/lib/Constants.ts
+++ b/website/src/lib/Constants.ts
@@ -5,11 +5,11 @@ type Endpoint = { id: string; label: string; website_url: string; services: Serv
 type Region = { id: string; label: string }
 
 const isPrefix = function (endpoint) {
-	return endpoint.services.filter((service) => service.type === 'prefix').length > 0
+  return endpoint.services.filter((service) => service.type === 'prefix').length > 0
 }
 
 const isHosting = function (endpoint) {
-	return !isPrefix(endpoint)
+  return !isPrefix(endpoint)
 }
 
 export const HOSTING: Endpoint[] = config.endpoints.filter(isHosting)
@@ -18,11 +18,11 @@ export const REGIONS: Region[] = config.regions
 export const SERVICE_TYPES: string[] = ['enclosure', 'feed', 'prefix']
 
 export const MONITORED = [...HOSTING, ...PREFIXES].reduce(
-	(acc, cur) => {
-		acc[cur.id] = cur
-		return acc
-	},
-	{} as { [key: string]: Endpoint }
+  (acc, cur) => {
+    acc[cur.id] = cur
+    return acc
+  },
+  {} as { [key: string]: Endpoint }
 )
 
 export const API_BASE_URL = config.base_url

--- a/website/src/lib/Ui.ts
+++ b/website/src/lib/Ui.ts
@@ -2,163 +2,163 @@ import { Detail, Instant, Issue, ServiceInstant } from '../types'
 import { HOSTING, PREFIXES, SERVICE_TYPES } from './Constants'
 
 const STATUS_BADGE_CLASSES = {
-	UP: ['text-lime-300', 'border-lime-600', 'hover:border-lime-300'],
-	DOWN: ['text-red-300', 'border-red-600', 'hover:border-red-300'],
-	PARTIAL: ['text-yellow-300', 'border-yellow-600', 'hover:border-yellow-300'],
-	UNKNOWN: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300'],
-	LOADING: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300']
+  UP: ['text-lime-300', 'border-lime-600', 'hover:border-lime-300'],
+  DOWN: ['text-red-300', 'border-red-600', 'hover:border-red-300'],
+  PARTIAL: ['text-yellow-300', 'border-yellow-600', 'hover:border-yellow-300'],
+  UNKNOWN: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300'],
+  LOADING: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300']
 }
 
 const STATUS_BADGE_LABELS = {
-	UP: 'UP',
-	DOWN: 'DOWN',
-	PARTIAL: 'PARTIAL',
-	UNKNOWN: 'UNKNOWN',
-	LOADING: '...'
+  UP: 'UP',
+  DOWN: 'DOWN',
+  PARTIAL: 'PARTIAL',
+  UNKNOWN: 'UNKNOWN',
+  LOADING: '...'
 }
 
 const DETAIL_CELL_CLASSES = {
-	UP: ['bg-lime-500', 'hover:bg-lime-300'],
-	DOWN: ['bg-red-500', 'hover:bg-red-300'],
-	PARTIAL: ['bg-yellow-500', 'hover:bg-yellow-300'],
-	UNKNOWN: ['bg-gray-500', 'hover:bg-gray-300'],
-	LOADING: ['bg-gray-500', 'hover:bg-gray-300']
+  UP: ['bg-lime-500', 'hover:bg-lime-300'],
+  DOWN: ['bg-red-500', 'hover:bg-red-300'],
+  PARTIAL: ['bg-yellow-500', 'hover:bg-yellow-300'],
+  UNKNOWN: ['bg-gray-500', 'hover:bg-gray-300'],
+  LOADING: ['bg-gray-500', 'hover:bg-gray-300']
 }
 
 const getStatus = (available: number | null | undefined) => {
-	if (typeof available === 'undefined') return 'LOADING'
-	if (available === 0) return 'DOWN'
-	if (available === 1) return 'UP'
-	if (available === null) return 'UNKNOWN'
-	return 'PARTIAL'
+  if (typeof available === 'undefined') return 'LOADING'
+  if (available === 0) return 'DOWN'
+  if (available === 1) return 'UP'
+  if (available === null) return 'UNKNOWN'
+  return 'PARTIAL'
 }
 
 function updateBadge(
-	element: HTMLElement | undefined | null,
-	available: number | null | undefined
+  element: HTMLElement | undefined | null,
+  available: number | null | undefined
 ) {
-	if (!element) return
-	element.classList.remove(
-		...STATUS_BADGE_CLASSES.UNKNOWN,
-		...STATUS_BADGE_CLASSES.UP,
-		...STATUS_BADGE_CLASSES.DOWN,
-		...STATUS_BADGE_CLASSES.PARTIAL,
-		...STATUS_BADGE_CLASSES.LOADING
-	)
-	element.classList.add(...STATUS_BADGE_CLASSES[getStatus(available)])
-	element.innerText = STATUS_BADGE_LABELS[getStatus(available)]
+  if (!element) return
+  element.classList.remove(
+    ...STATUS_BADGE_CLASSES.UNKNOWN,
+    ...STATUS_BADGE_CLASSES.UP,
+    ...STATUS_BADGE_CLASSES.DOWN,
+    ...STATUS_BADGE_CLASSES.PARTIAL,
+    ...STATUS_BADGE_CLASSES.LOADING
+  )
+  element.classList.add(...STATUS_BADGE_CLASSES[getStatus(available)])
+  element.innerText = STATUS_BADGE_LABELS[getStatus(available)]
 }
 
 export function updateStatusBadge(instant: Instant) {
-	updateBadge(document.getElementById(`status-badge-${instant.endpoint}`), instant.available)
+  updateBadge(document.getElementById(`status-badge-${instant.endpoint}`), instant.available)
 }
 
 export function updateServiceStatusBadges(endpoint: string, data: ServiceInstant[]) {
-	if (data.length === 0) {
-		SERVICE_TYPES.forEach((type) => {
-			updateBadge(document.getElementById(`status-badge-${endpoint}-${type}`), undefined)
-		})
-	}
-	data.forEach((instant) => {
-		updateBadge(
-			document.getElementById(`status-badge-${endpoint}-${instant.type}`),
-			instant.available
-		)
-	})
+  if (data.length === 0) {
+    SERVICE_TYPES.forEach((type) => {
+      updateBadge(document.getElementById(`status-badge-${endpoint}-${type}`), undefined)
+    })
+  }
+  data.forEach((instant) => {
+    updateBadge(
+      document.getElementById(`status-badge-${endpoint}-${instant.type}`),
+      instant.available
+    )
+  })
 }
 
 export function updateStatusBadges(data: Instant[]) {
-	if (data.length === 0) {
-		;[...HOSTING, ...PREFIXES].forEach((item) => {
-			updateStatusBadge({ endpoint: item.id, available: undefined })
-		})
-	}
-	data.forEach((instant) => {
-		updateStatusBadge(instant)
-	})
+  if (data.length === 0) {
+    ;[...HOSTING, ...PREFIXES].forEach((item) => {
+      updateStatusBadge({ endpoint: item.id, available: undefined })
+    })
+  }
+  data.forEach((instant) => {
+    updateStatusBadge(instant)
+  })
 }
 
 export function updateDetailedGrid(data: Detail[]) {
-	if (data.length === 0) {
-		for (let i = 0; i < 1440; i++) {
-			const col = i % 60
-			const row = Math.floor(i / 60)
-			const cell = document.getElementById(`detail-cell-${row}-${col}`)
-			const cellText = document.getElementById(`detail-cell-text-${row}-${col}`)
-			if (cell && cellText) {
-				cell.classList.remove(
-					...DETAIL_CELL_CLASSES['UNKNOWN'],
-					...DETAIL_CELL_CLASSES['UP'],
-					...DETAIL_CELL_CLASSES['DOWN'],
-					...DETAIL_CELL_CLASSES['PARTIAL'],
-					...DETAIL_CELL_CLASSES['LOADING']
-				)
-				cell.classList.add(...DETAIL_CELL_CLASSES['LOADING'])
-				cellText.innerText = `...`
-			}
-		}
-	}
-	data.forEach((item, i) => {
-		const col = i % 60
-		const row = Math.floor(i / 60)
-		const cell = document.getElementById(`detail-cell-${row}-${col}`)
-		const cellText = document.getElementById(`detail-cell-text-${row}-${col}`)
-		if (cell && cellText) {
-			cell.classList.remove(...DETAIL_CELL_CLASSES['LOADING'])
-			cell.classList.add(...DETAIL_CELL_CLASSES[getStatus(item.available)])
-			const time = new Date(item.timestamp)
-			cellText.innerHTML = `${new Intl.DateTimeFormat('default', {
-				year: 'numeric',
-				month: 'numeric',
-				day: 'numeric'
-			}).format(time)}&nbsp;-&nbsp;${new Intl.DateTimeFormat('default', {
-				hour: 'numeric',
-				minute: 'numeric',
-				timeZone: 'UTC'
-			}).format(time)}`
-		}
-	})
+  if (data.length === 0) {
+    for (let i = 0; i < 1440; i++) {
+      const col = i % 60
+      const row = Math.floor(i / 60)
+      const cell = document.getElementById(`detail-cell-${row}-${col}`)
+      const cellText = document.getElementById(`detail-cell-text-${row}-${col}`)
+      if (cell && cellText) {
+        cell.classList.remove(
+          ...DETAIL_CELL_CLASSES['UNKNOWN'],
+          ...DETAIL_CELL_CLASSES['UP'],
+          ...DETAIL_CELL_CLASSES['DOWN'],
+          ...DETAIL_CELL_CLASSES['PARTIAL'],
+          ...DETAIL_CELL_CLASSES['LOADING']
+        )
+        cell.classList.add(...DETAIL_CELL_CLASSES['LOADING'])
+        cellText.innerText = `...`
+      }
+    }
+  }
+  data.forEach((item, i) => {
+    const col = i % 60
+    const row = Math.floor(i / 60)
+    const cell = document.getElementById(`detail-cell-${row}-${col}`)
+    const cellText = document.getElementById(`detail-cell-text-${row}-${col}`)
+    if (cell && cellText) {
+      cell.classList.remove(...DETAIL_CELL_CLASSES['LOADING'])
+      cell.classList.add(...DETAIL_CELL_CLASSES[getStatus(item.available)])
+      const time = new Date(item.timestamp)
+      cellText.innerHTML = `${new Intl.DateTimeFormat('default', {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric'
+      }).format(time)}&nbsp;-&nbsp;${new Intl.DateTimeFormat('default', {
+        hour: 'numeric',
+        minute: 'numeric',
+        timeZone: 'UTC'
+      }).format(time)}`
+    }
+  })
 }
 
 function renderIssue(issue: Issue) {
-	return `
+  return `
 		<li class="pt-1">
 			<div
 				onclick="document.getElementById('${`issue-detail-${issue.id}`}').classList.toggle('hidden')"
 				class="underline cursor-pointer text-sm"
 			>
 				${new Intl.DateTimeFormat('default', {
-					year: 'numeric',
-					month: 'numeric',
-					day: 'numeric',
-					minute: 'numeric',
-					hour: 'numeric',
-					timeZone: 'UTC'
-				}).format(new Date(issue.timestamp))} | ${issue.type} | ${issue.region}
+          year: 'numeric',
+          month: 'numeric',
+          day: 'numeric',
+          minute: 'numeric',
+          hour: 'numeric',
+          timeZone: 'UTC'
+        }).format(new Date(issue.timestamp))} | ${issue.type} | ${issue.region}
 			</div>
 			<pre id="issue-detail-${issue.id}" class="text-xs hidden pt-1">${JSON.stringify(
-				issue,
-				null,
-				2
-			)}</pre>
+        issue,
+        null,
+        2
+      )}</pre>
 		</li>`
 }
 
 export function updateRecentIssues(issues: Issue[] | null) {
-	const element = document.getElementById('recent-issues')
-	if (!element) return
-	// Loading
-	if (!issues) {
-		element.innerHTML = `<div class="text-sm">...</div>`
-		return
-	}
-	// No issues
-	if (issues.length === 0) {
-		element.innerHTML = `<div class="text-sm">No recent issues</div>`
-		return
-	}
-	// Issues
-	element.innerHTML = `
+  const element = document.getElementById('recent-issues')
+  if (!element) return
+  // Loading
+  if (!issues) {
+    element.innerHTML = `<div class="text-sm">...</div>`
+    return
+  }
+  // No issues
+  if (issues.length === 0) {
+    element.innerHTML = `<div class="text-sm">No recent issues</div>`
+    return
+  }
+  // Issues
+  element.innerHTML = `
 	<ul class="list-disc list-outside pl-4">
 		${issues.map(renderIssue).join('')}
 	</ul>

--- a/website/src/lib/Ui.ts
+++ b/website/src/lib/Ui.ts
@@ -1,4 +1,4 @@
-import { Detail, Instant, ServiceInstant } from '../types'
+import { Detail, Instant, Issue, ServiceInstant } from '../types'
 import { HOSTING, PREFIXES, SERVICE_TYPES } from './Constants'
 
 const STATUS_BADGE_CLASSES = {
@@ -118,4 +118,49 @@ export function updateDetailedGrid(data: Detail[]) {
 			}).format(time)}`
 		}
 	})
+}
+
+function renderIssue(issue: Issue) {
+	return `
+		<li class="pt-1">
+			<div
+				onclick="document.getElementById('${`issue-detail-${issue.id}`}').classList.toggle('hidden')"
+				class="underline cursor-pointer text-sm"
+			>
+				${new Intl.DateTimeFormat('default', {
+					year: 'numeric',
+					month: 'numeric',
+					day: 'numeric',
+					minute: 'numeric',
+					hour: 'numeric',
+					timeZone: 'UTC'
+				}).format(new Date(issue.timestamp))} | ${issue.type} | ${issue.region}
+			</div>
+			<pre id="issue-detail-${issue.id}" class="text-xs hidden pt-1">${JSON.stringify(
+				issue,
+				null,
+				2
+			)}</pre>
+		</li>`
+}
+
+export function updateRecentIssues(issues: Issue[] | null) {
+	const element = document.getElementById('recent-issues')
+	if (!element) return
+	// Loading
+	if (!issues) {
+		element.innerHTML = `<div class="text-sm">...</div>`
+		return
+	}
+	// No issues
+	if (issues.length === 0) {
+		element.innerHTML = `<div class="text-sm">No recent issues</div>`
+		return
+	}
+	// Issues
+	element.innerHTML = `
+	<ul class="list-disc list-outside pl-4">
+		${issues.map(renderIssue).join('')}
+	</ul>
+	`
 }

--- a/website/src/pages/[endpoint].astro
+++ b/website/src/pages/[endpoint].astro
@@ -5,21 +5,21 @@ import { MONITORED, REGIONS } from '../lib/Constants'
 const MATRIX: number[][] = []
 
 for (let i = 0; i < 24; i++) {
-	let ROW: number[] = []
-	for (let j = 0; j < 60; j++) {
-		ROW.push(1)
-	}
-	MATRIX.push(ROW)
+  let ROW: number[] = []
+  for (let j = 0; j < 60; j++) {
+    ROW.push(1)
+  }
+  MATRIX.push(ROW)
 }
 
 export function getStaticPaths() {
-	return Object.keys(MONITORED).map((id) => {
-		return {
-			params: {
-				endpoint: id
-			}
-		}
-	})
+  return Object.keys(MONITORED).map((id) => {
+    return {
+      params: {
+        endpoint: id
+      }
+    }
+  })
 }
 
 const endpointId = Astro.params.endpoint
@@ -29,157 +29,157 @@ const endpointServices = MONITORED[endpointId || ''].services
 ---
 
 <Layout title={`PodUptime | ${endpointLabel}`} headerLink="/">
-	<div id="data" data-vars={JSON.stringify({ id: endpointId })}></div>
-	<div class="flex flex-col items-start sm:flex-row sm:items-center">
-		<h1 class="flex-grow text-4xl font-bold text-pink-100">{endpointLabel}</h1>
-		<select
-			id="region"
-			class="mt-2 rounded border-2 border-pink-200 bg-blue-950 px-2 py-2 text-center text-xs font-bold text-pink-200 sm:mt-0"
-		>
-			{
-				REGIONS.map((region) => {
-					return <option value={region.id}>{region.label}</option>
-				})
-			}
-		</select>
-	</div>
-	<p class="pb-6 pt-4">
-		On this page, you can view the detailed status of the monitored endpoint for <a
-			class="underline"
-			target="_blank"
-			href={endpointWebsiteUrl}>{endpointLabel} ↗</a
-		>. The status is updated every minute from multiple locations around the world. All times are in
+  <div id="data" data-vars={JSON.stringify({ id: endpointId })}></div>
+  <div class="flex flex-col items-start sm:flex-row sm:items-center">
+    <h1 class="flex-grow text-4xl font-bold text-pink-100">{endpointLabel}</h1>
+    <select
+      id="region"
+      class="mt-2 rounded border-2 border-pink-200 bg-blue-950 px-2 py-2 text-center text-xs font-bold text-pink-200 sm:mt-0"
+    >
+      {
+        REGIONS.map((region) => {
+          return <option value={region.id}>{region.label}</option>
+        })
+      }
+    </select>
+  </div>
+  <p class="pb-6 pt-4">
+    On this page, you can view the detailed status of the monitored endpoint for <a
+      class="underline"
+      target="_blank"
+      href={endpointWebsiteUrl}>{endpointLabel} ↗</a
+    >. The status is updated every minute from multiple locations around the world. All times are in
 
 
-		<code>UTC</code>.
-	</p>
-	<div class="flex items-baseline border-b-2 border-dotted border-pink-100 pb-2">
-		<h2 class="flex-grow text-2xl font-bold text-pink-100">Instant Status</h2>
-		<span class="text-xs">last 30 minutes</span>
-	</div>
-	<div class="pt-4">
-		<p class="pb-2 text-xs font-bold">Monitored URL(s):</p>
-		{
-			endpointServices.map((service) => {
-				return (
-					<div class="flex items-center justify-between pb-2">
-						<code class="break-all pr-2 text-xs">{service.url}</code>
-						<div
-							id={`status-badge-${endpointId}-${service.type}`}
-							class="inline-block w-24 shrink-0 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
-						>
-							...
-						</div>
-					</div>
-				)
-			})
-		}
+    <code>UTC</code>.
+  </p>
+  <div class="flex items-baseline border-b-2 border-dotted border-pink-100 pb-2">
+    <h2 class="flex-grow text-2xl font-bold text-pink-100">Instant Status</h2>
+    <span class="text-xs">last 30 minutes</span>
+  </div>
+  <div class="pt-4">
+    <p class="pb-2 text-xs font-bold">Monitored URL(s):</p>
+    {
+      endpointServices.map((service) => {
+        return (
+          <div class="flex items-center justify-between pb-2">
+            <code class="break-all pr-2 text-xs">{service.url}</code>
+            <div
+              id={`status-badge-${endpointId}-${service.type}`}
+              class="inline-block w-24 shrink-0 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
+            >
+              ...
+            </div>
+          </div>
+        )
+      })
+    }
 
-		<div class="flex-shrink break-after-all break-all pr-4 text-xs"></div>
-	</div>
-	<div class="flex items-baseline border-b-2 border-dotted border-pink-100 pt-6">
-		<h2 class="flex-grow pb-2 text-2xl font-bold text-pink-100">Detailed Status</h2>
-		<span class="text-xs">last 24 hours</span>
-	</div>
-	<table class="mt-4 w-full opacity-80">
-		<tbody>
-			{
-				MATRIX.map((row, i) => {
-					return (
-						<tr>
-							{row.map((col, j) => (
-								<td
-									id={`detail-cell-${i}-${j}`}
-									class={[
-										'bg-gray-500',
-										'hover:bg-gray-300',
-										'text-white',
-										'border',
-										'border-transparent',
-										'w-2',
-										'sm:w-3',
-										'h-2',
-										'sm:h-3',
-										'aspect-square',
-										'group',
-										'transition-colors',
-										'duration-500',
-										'relative'
-									].join(' ')}
-								>
-									<span
-										id={`detail-cell-text-${i}-${j}`}
-										class="absolute top-4 z-10 hidden rounded bg-zinc-950 px-3 py-2 text-xs font-thin group-hover:block"
-									>
-										...
-									</span>
-								</td>
-							))}
-						</tr>
-					)
-				})
-			}
-		</tbody>
-	</table>
-	<ul class="grid grid-cols-2 pt-1 sm:flex">
-		<li>
-			<span class="mr-2 inline-block h-3 w-3 bg-lime-500"></span><span class="pr-2 text-xs">UP</span
-			>
-		</li>
-		<li>
-			<span class="mr-2 inline-block h-3 w-3 bg-yellow-500"></span><span class="pr-2 text-xs"
-				>PARTIAL</span
-			>
-		</li>
-		<li>
-			<span class="mr-2 inline-block h-3 w-3 bg-red-500"></span><span class="pr-2 text-xs"
-				>DOWN</span
-			>
-		</li>
-		<li>
-			<span class="mr-2 inline-block h-3 w-3 bg-gray-500"></span><span class="pr-2 text-xs"
-				>UNKNOWN</span
-			>
-		</li>
-		<li class="sm:ml-auto">
-			<a class="text-xs underline" href="/about/">Learn more ↗</a>
-		</li>
-	</ul>
-	<div class="flex items-baseline border-b-2 border-dotted border-pink-100 pt-6">
-		<h2 class="flex-grow pb-2 text-2xl font-bold text-pink-100">Recent Issues</h2>
-		<span class="text-xs">10 most recent</span>
-	</div>
-	<div class="pt-2" id="recent-issues"><div class="text-sm">...</div></div>
+    <div class="flex-shrink break-after-all break-all pr-4 text-xs"></div>
+  </div>
+  <div class="flex items-baseline border-b-2 border-dotted border-pink-100 pt-6">
+    <h2 class="flex-grow pb-2 text-2xl font-bold text-pink-100">Detailed Status</h2>
+    <span class="text-xs">last 24 hours</span>
+  </div>
+  <table class="mt-4 w-full opacity-80">
+    <tbody>
+      {
+        MATRIX.map((row, i) => {
+          return (
+            <tr>
+              {row.map((col, j) => (
+                <td
+                  id={`detail-cell-${i}-${j}`}
+                  class={[
+                    'bg-gray-500',
+                    'hover:bg-gray-300',
+                    'text-white',
+                    'border',
+                    'border-transparent',
+                    'w-2',
+                    'sm:w-3',
+                    'h-2',
+                    'sm:h-3',
+                    'aspect-square',
+                    'group',
+                    'transition-colors',
+                    'duration-500',
+                    'relative'
+                  ].join(' ')}
+                >
+                  <span
+                    id={`detail-cell-text-${i}-${j}`}
+                    class="absolute top-4 z-10 hidden rounded bg-zinc-950 px-3 py-2 text-xs font-thin group-hover:block"
+                  >
+                    ...
+                  </span>
+                </td>
+              ))}
+            </tr>
+          )
+        })
+      }
+    </tbody>
+  </table>
+  <ul class="grid grid-cols-2 pt-1 sm:flex">
+    <li>
+      <span class="mr-2 inline-block h-3 w-3 bg-lime-500"></span><span class="pr-2 text-xs">UP</span
+      >
+    </li>
+    <li>
+      <span class="mr-2 inline-block h-3 w-3 bg-yellow-500"></span><span class="pr-2 text-xs"
+        >PARTIAL</span
+      >
+    </li>
+    <li>
+      <span class="mr-2 inline-block h-3 w-3 bg-red-500"></span><span class="pr-2 text-xs"
+        >DOWN</span
+      >
+    </li>
+    <li>
+      <span class="mr-2 inline-block h-3 w-3 bg-gray-500"></span><span class="pr-2 text-xs"
+        >UNKNOWN</span
+      >
+    </li>
+    <li class="sm:ml-auto">
+      <a class="text-xs underline" href="/about/">Learn more ↗</a>
+    </li>
+  </ul>
+  <div class="flex items-baseline border-b-2 border-dotted border-pink-100 pt-6">
+    <h2 class="flex-grow pb-2 text-2xl font-bold text-pink-100">Recent Issues</h2>
+    <span class="text-xs">10 most recent</span>
+  </div>
+  <div class="pt-2" id="recent-issues"><div class="text-sm">...</div></div>
 </Layout>
 
 <script>
-	import { fetchDetailedAndServiceInstantsAndRecentIssuesData } from '../lib/Api'
-	import { updateDetailedGrid, updateServiceStatusBadges, updateRecentIssues } from '../lib/Ui'
+  import { fetchDetailedAndServiceInstantsAndRecentIssuesData } from '../lib/Api'
+  import { updateDetailedGrid, updateServiceStatusBadges, updateRecentIssues } from '../lib/Ui'
 
-	const vars = JSON.parse(document.getElementById('data')?.dataset.vars || '{}')
-	const endpointId = vars.id || ''
+  const vars = JSON.parse(document.getElementById('data')?.dataset.vars || '{}')
+  const endpointId = vars.id || ''
 
-	document.getElementById('region')?.addEventListener('change', async (event) => {
-		const region = (event.target as HTMLSelectElement).value
-		updateDetailedGrid([])
-		updateServiceStatusBadges(endpointId, [])
-		updateRecentIssues(null)
-		const { instants, detailed, issues } = await fetchDetailedAndServiceInstantsAndRecentIssuesData(
-			endpointId,
-			region
-		)
-		updateDetailedGrid(detailed)
-		updateServiceStatusBadges(endpointId, instants)
-		updateRecentIssues(issues)
-	})
+  document.getElementById('region')?.addEventListener('change', async (event) => {
+    const region = (event.target as HTMLSelectElement).value
+    updateDetailedGrid([])
+    updateServiceStatusBadges(endpointId, [])
+    updateRecentIssues(null)
+    const { instants, detailed, issues } = await fetchDetailedAndServiceInstantsAndRecentIssuesData(
+      endpointId,
+      region
+    )
+    updateDetailedGrid(detailed)
+    updateServiceStatusBadges(endpointId, instants)
+    updateRecentIssues(issues)
+  })
 
-	// Render data for global region
-	const { instants, detailed, issues } = await fetchDetailedAndServiceInstantsAndRecentIssuesData(
-		endpointId,
-		'global'
-	)
+  // Render data for global region
+  const { instants, detailed, issues } = await fetchDetailedAndServiceInstantsAndRecentIssuesData(
+    endpointId,
+    'global'
+  )
 
-	updateDetailedGrid(detailed)
-	updateServiceStatusBadges(endpointId, instants)
-	updateRecentIssues(issues)
+  updateDetailedGrid(detailed)
+  updateServiceStatusBadges(endpointId, instants)
+  updateRecentIssues(issues)
 </script>

--- a/website/src/pages/[endpoint].astro
+++ b/website/src/pages/[endpoint].astro
@@ -145,11 +145,16 @@ const endpointServices = MONITORED[endpointId || ''].services
 			<a class="text-xs underline" href="/about/">Learn more ↗</a>
 		</li>
 	</ul>
+	<div class="flex items-baseline border-b-2 border-dotted border-pink-100 pt-6">
+		<h2 class="flex-grow pb-2 text-2xl font-bold text-pink-100">Recent Issues</h2>
+		<span class="text-xs">10 most recent</span>
+	</div>
+	<div class="pt-2" id="recent-issues"><div class="text-sm">...</div></div>
 </Layout>
 
 <script>
-	import { fetchDetailedAndServiceInstantsData } from '../lib/Api'
-	import { updateDetailedGrid, updateServiceStatusBadges } from '../lib/Ui'
+	import { fetchDetailedAndServiceInstantsAndRecentIssuesData } from '../lib/Api'
+	import { updateDetailedGrid, updateServiceStatusBadges, updateRecentIssues } from '../lib/Ui'
 
 	const vars = JSON.parse(document.getElementById('data')?.dataset.vars || '{}')
 	const endpointId = vars.id || ''
@@ -158,13 +163,23 @@ const endpointServices = MONITORED[endpointId || ''].services
 		const region = (event.target as HTMLSelectElement).value
 		updateDetailedGrid([])
 		updateServiceStatusBadges(endpointId, [])
-		const { instants, detailed } = await fetchDetailedAndServiceInstantsData(endpointId, region)
+		updateRecentIssues(null)
+		const { instants, detailed, issues } = await fetchDetailedAndServiceInstantsAndRecentIssuesData(
+			endpointId,
+			region
+		)
 		updateDetailedGrid(detailed)
 		updateServiceStatusBadges(endpointId, instants)
+		updateRecentIssues(issues)
 	})
 
 	// Render data for global region
-	const { instants, detailed } = await fetchDetailedAndServiceInstantsData(endpointId, 'global')
+	const { instants, detailed, issues } = await fetchDetailedAndServiceInstantsAndRecentIssuesData(
+		endpointId,
+		'global'
+	)
+
 	updateDetailedGrid(detailed)
 	updateServiceStatusBadges(endpointId, instants)
+	updateRecentIssues(issues)
 </script>

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -4,167 +4,169 @@ import Layout from '../layouts/Layout.astro'
 ---
 
 <Layout title="PodUptime | About" headerLink="/">
-	<h1 class="mb-4 text-4xl font-bold text-pink-100">About PodUptime</h1>
+  <h1 class="mb-4 text-4xl font-bold text-pink-100">About PodUptime</h1>
 
-	<p class="mb-4">
-		PodUptime is a distributed uptime monitoring system for the podcast industry, measuring
-		availability of hosting platforms and tracking prefixes.
-	</p>
+  <p class="mb-4">
+    PodUptime is a distributed uptime monitoring system for the podcast industry, measuring
+    availability of hosting platforms and tracking prefixes.
+  </p>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		How does it work?
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    How does it work?
+  </h2>
 
-	<p class="mb-4 [&>code]:underline">
-		The measurement process involves regularly conducting an <code>HTTP HEAD</code> request against
-		a media enclosure <code>URL</code>, which is typically found in podcast <code>RSS</code> feeds.
-		We gather data from various AWS regions, each of which performs an <code>HTTP HEAD</code>
-		 request every minute on every monitored service. These regions include <code>us-west-1</code>,
-		<code>us-east-2</code>, and <code>eu-south-1</code>, carefully chosen to avoid regions where
-		most companies typically run their workloads, ensuring an unbiased measurement.
-	</p>
+  <p class="mb-4 [&>code]:underline">
+    The measurement process involves regularly conducting an <code>HTTP HEAD</code> request against
+    a media enclosure <code>URL</code>, which is typically found in podcast <code>RSS</code> feeds.
+    We gather data from various AWS regions, each of which performs an <code>HTTP HEAD</code>
+     request every minute on every monitored service. These regions include <code>us-west-1</code>,
+    <code>us-east-2</code>, and <code>eu-south-1</code>, carefully chosen to avoid regions where
+    most companies typically run their workloads, ensuring an unbiased measurement.
+  </p>
 
-	<p class="mb-4 [&>code]:underline">
-		The <code>User-Agent</code> being used to perform these requests is:
-		<code>Mozilla/5.0 (compatible; PodUptimeBot/1.0; +https://poduptime.com; rid:XXX)</code>. The <code
-			>rid</code
-		>
-		 property represents a random GUID (eg: <code>0e7f5251-9d03-4371-8186-a82ca9c5235e</code>) which
-		is utilized to persist the request results in our internal database, facilitating debugging
-		purposes. Additionally, it ensures that consecutive checks conducted on the same endpoint are
-		not treated as originating from the same listener, in accordance with the IAB definition, and
-		prevents short-circuiting of a pre-existing cached response.
-	</p>
+  <p class="mb-4 [&>code]:underline">
+    The <code>User-Agent</code> being used to perform these requests is:
+    <code>Mozilla/5.0 (compatible; PodUptimeBot/1.0; +https://poduptime.com; rid:XXX)</code>. The <code
+      >rid</code
+    >
+     property represents a random GUID (eg: <code>0e7f5251-9d03-4371-8186-a82ca9c5235e</code>) which
+    is utilized to persist the request results in our internal database, facilitating debugging
+    purposes. Additionally, it ensures that consecutive checks conducted on the same endpoint are
+    not treated as originating from the same listener, in accordance with the IAB definition, and
+    prevents short-circuiting of a pre-existing cached response.
+  </p>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		How is availability established?
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    How is availability established?
+  </h2>
 
-	<p class="mb-4">Availability is established differently based on the type of the target:</p>
+  <p class="mb-4">Availability is established differently based on the type of the target:</p>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			<strong class="font-bold text-pink-100">Tracking prefixes</strong> are considered&nbsp;&nbsp;
-			<Status type="UP" />&nbsp;&nbsp;if they promptly redirect to the prefixed <code>URL</code>
-			 with one of the following <code>HTTP</code> status codes: <code>301</code>, <code>302</code>,
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      <strong class="font-bold text-pink-100">Tracking prefixes</strong> are considered&nbsp;&nbsp;
+      <Status type="UP" />&nbsp;&nbsp;if they promptly redirect to the prefixed <code>URL</code>
+       with one of the following <code>HTTP</code> status codes: <code>301</code>, <code>302</code>,
 
 
-			<code>303</code>, <code>307</code>, or <code>308</code>. The redirection itself is not
-			followed, ensuring that the measured duration represents the actual time it takes for the
-			prefix to initiate the redirect.
-		</li>
-		<li class="[&>code]:underline">
-			<strong class="font-bold text-pink-100">Hosting platforms</strong> are considered&nbsp;&nbsp;
-			<Status type="UP" />&nbsp;&nbsp;if they respond with an <code>HTTP</code>
-			 status code <code>200</code> to a request made to the monitored URL, following any redirects.
-			In this scenario, the measured duration reflects the actual time it takes for the client to
-			reach the destination of the <code>HEAD</code> request.
-		</li>
-	</ul>
+      <code>303</code>, <code>307</code>, or <code>308</code>. The redirection itself is not
+      followed, ensuring that the measured duration represents the actual time it takes for the
+      prefix to initiate the redirect.
+    </li>
+    <li class="[&>code]:underline">
+      <strong class="font-bold text-pink-100">Hosting platforms</strong> are considered&nbsp;&nbsp;
+      <Status type="UP" />&nbsp;&nbsp;if they respond with an <code>HTTP</code>
+       status code <code>200</code> to a request made to the monitored URL, following any redirects.
+      In this scenario, the measured duration reflects the actual time it takes for the client to
+      reach the destination of the <code>HEAD</code> request.
+    </li>
+  </ul>
 
-	<p class="mb-4">
-		The status shown in the homepage represent the availability over the last 30 minutes and it is
-		reported as follows:
-	</p>
-	<table class="mb-4">
-		<thead>
-			<tr>
-				<th class="px-4 py-2">Status</th>
-				<th class="px-4 py-2">Availability</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td class="border border-dotted px-4 py-2">
-					<Status type="UP" />
-				</td>
-				<td class="border border-dotted px-4 py-2"
-					>The endpoint consistently showed as &nbsp;
-					<Status type="UP" />
-				</td>
-			</tr>
-			<tr>
-				<td class="border border-dotted px-4 py-2">
-					<Status type="PARTIAL" />
-				</td>
-				<td class="border border-dotted px-4 py-2"
-					>The endpoint was detected as &nbsp;
-					<Status type="UP" />&nbsp; in certain regions or moments and as &nbsp;
-					<Status type="DOWN" />&nbsp; in others
-				</td>
-			</tr>
-			<tr>
-				<td class="border border-dotted px-4 py-2">
-					<Status type="DOWN" />
-				</td>
-				<td class="border border-dotted px-4 py-2"
-					>The endpoint consistently showed as &nbsp;
-					<Status type="DOWN" />&nbsp;
-				</td>
-			</tr>
-			<tr>
-				<td class="border border-dotted px-4 py-2">
-					<Status type="UNKNOWN" />
-				</td>
-				<td class="border border-dotted px-4 py-2">No data is available for the endpoint</td>
-			</tr>
-		</tbody>
-	</table>
+  <p class="mb-4">
+    The status shown in the homepage represent the availability over the last 30 minutes and it is
+    reported as follows:
+  </p>
+  <table class="mb-4">
+    <thead>
+      <tr>
+        <th class="px-4 py-2">Status</th>
+        <th class="px-4 py-2">Availability</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="border border-dotted px-4 py-2">
+          <Status type="UP" />
+        </td>
+        <td class="border border-dotted px-4 py-2"
+          >The endpoint consistently showed as &nbsp;
+          <Status type="UP" />
+        </td>
+      </tr>
+      <tr>
+        <td class="border border-dotted px-4 py-2">
+          <Status type="PARTIAL" />
+        </td>
+        <td class="border border-dotted px-4 py-2"
+          >The endpoint was detected as &nbsp;
+          <Status type="UP" />&nbsp; in certain regions or moments and as &nbsp;
+          <Status type="DOWN" />&nbsp; in others
+        </td>
+      </tr>
+      <tr>
+        <td class="border border-dotted px-4 py-2">
+          <Status type="DOWN" />
+        </td>
+        <td class="border border-dotted px-4 py-2"
+          >The endpoint consistently showed as &nbsp;
+          <Status type="DOWN" />&nbsp;
+        </td>
+      </tr>
+      <tr>
+        <td class="border border-dotted px-4 py-2">
+          <Status type="UNKNOWN" />
+        </td>
+        <td class="border border-dotted px-4 py-2">No data is available for the endpoint</td>
+      </tr>
+    </tbody>
+  </table>
 
-	<p class="mb-4">
-		Furthermore, to minimize false positives and ensure fairness in our measurements, an endpoint is
-		classified as &nbsp;&nbsp;
-		<Status type="DOWN" />&nbsp;&nbsp; only when two consecutive measurements from the same region
-		confirm its status.
-	</p>
+  <p class="mb-4">
+    Furthermore, to minimize false positives and ensure fairness in our measurements, an endpoint is
+    classified as &nbsp;&nbsp;
+    <Status type="DOWN" />&nbsp;&nbsp; only when two consecutive measurements from the same region
+    confirm its status.
+  </p>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		Why is a particular hosting platform / prefix missing?
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    Why is a particular hosting platform / prefix missing?
+  </h2>
 
-	<p class="mb-4">
-		It's possible that we may have missed it, or the specific platform might not allow the creation
-		of a free account, and we do not have an existing one to use. Please get in touch with us via
-		email at poduptime@spreaker.com, and we will do our best to incorporate your chosen platform or
-		prefix.
-	</p>
+  <p class="mb-4">
+    It's possible that we may have missed it, or the specific platform might not allow the creation
+    of a free account, and we do not have an existing one to use. Please get in touch with us via
+    email at poduptime@spreaker.com, and we will do our best to incorporate your chosen platform or
+    prefix.
+  </p>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		I see this is made by an hosting platform, is it biased?
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    I see this is made by an hosting platform, is it biased?
+  </h2>
 
-	<p class="mb-4">
-		Every service we monitor receives equal visibility, and the testing methodology is explained in detail.
-		If you find this information insufficient, you can review the source code of the project on
-		<a class="underline" href="https://github.com/spreaker/poduptime">GitHub</a>. We believe that releasing the code as open source
-		addresses any concerns or doubts about fair measurement. However, if you still have any questions
-		or require further clarification, please feel free to get in touch, and we'll be happy to assist.
-	</p>
+  <p class="mb-4">
+    Every service we monitor receives equal visibility, and the testing methodology is explained in
+    detail. If you find this information insufficient, you can review the source code of the project
+    on
+    <a class="underline" href="https://github.com/spreaker/poduptime">GitHub</a>. We believe that
+    releasing the code as open source addresses any concerns or doubts about fair measurement.
+    However, if you still have any questions or require further clarification, please feel free to
+    get in touch, and we'll be happy to assist.
+  </p>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		Do you keep a changelog?
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    Do you keep a changelog?
+  </h2>
 
-	<p class="mb-4">
-		Yes, we maintain a <a class="font-normal underline" href="/changelog/">Changelog</a> where you
-		can review all the changes that have been implemented in this monitoring system over time.
-	</p>
+  <p class="mb-4">
+    Yes, we maintain a <a class="font-normal underline" href="/changelog/">Changelog</a> where you
+    can review all the changes that have been implemented in this monitoring system over time.
+  </p>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		I have other questions, how can I reach out?
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    I have other questions, how can I reach out?
+  </h2>
 
-	<p class="mb-4">Please send us an email at poduptime@spreaker.com</p>
+  <p class="mb-4">Please send us an email at poduptime@spreaker.com</p>
 </Layout>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -3,160 +3,160 @@ import Layout from '../layouts/Layout.astro'
 ---
 
 <Layout title="PodUptime | Changelog" headerLink="/">
-	<h1 class="mb-4 text-4xl font-bold text-pink-100">Changelog</h1>
+  <h1 class="mb-4 text-4xl font-bold text-pink-100">Changelog</h1>
 
-	<p class="mb-4">
-		This page contains the list of changes made to PodUptime's monitoring system and website.
-	</p>
+  <p class="mb-4">
+    This page contains the list of changes made to PodUptime's monitoring system and website.
+  </p>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 30th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 30th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			For debugging purposes, we have implemented the display of the full event for the last 10
-			issues in the detail view for each service. This enhancement aims to assist in troubleshooting
-			and diagnosing any problems effectively.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      For debugging purposes, we have implemented the display of the full event for the last 10
+      issues in the detail view for each service. This enhancement aims to assist in troubleshooting
+      and diagnosing any problems effectively.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 27th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 27th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			We added the following services to our monitoring list: <code>Audioboom</code> and <code
-				>iVoox</code
-			>.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We added the following services to our monitoring list: <code>Audioboom</code> and <code
+        >iVoox</code
+      >.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 26th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 26th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			We have released the source code of the project on <a
-				class="underline"
-				href="https://github.com/spreaker/poduptime">GitHub</a
-			>.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We have released the source code of the project on <a
+        class="underline"
+        href="https://github.com/spreaker/poduptime">GitHub</a
+      >.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 25th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 25th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			In the detail view for each service we now show the instant status for each monitored <code
-				>URL</code
-			>.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      In the detail view for each service we now show the instant status for each monitored <code
+        >URL</code
+      >.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 13th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 13th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			We've included <code>RSS feed</code> monitoring for hosting platforms. Similar to our
-			enclosure checks, this is performed with an <code>HTTP HEAD</code> request directed at the RSS
-			feed of a dummy podcast used by our monitoring service. The results of these additional checks
-			are combined with the enclosure checks to determine overall availability.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We've included <code>RSS feed</code> monitoring for hosting platforms. Similar to our
+      enclosure checks, this is performed with an <code>HTTP HEAD</code> request directed at the RSS
+      feed of a dummy podcast used by our monitoring service. The results of these additional checks
+      are combined with the enclosure checks to determine overall availability.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 11th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 11th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			We added the following services to our monitoring list: <code>Alitu</code>.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We added the following services to our monitoring list: <code>Alitu</code>.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 10th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 10th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			We added a detailed view for each service, showing the instant status and the last 24 hours of
-			data.
-		</li>
-		<li class="pb-3 [&>code]:underline">We made some minor UI improvements to the website.</li>
-		<li class="pb-3 [&>code]:underline">
-			We added the following services to our monitoring list: <code>Podscribe</code>.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We added a detailed view for each service, showing the instant status and the last 24 hours of
+      data.
+    </li>
+    <li class="pb-3 [&>code]:underline">We made some minor UI improvements to the website.</li>
+    <li class="pb-3 [&>code]:underline">
+      We added the following services to our monitoring list: <code>Podscribe</code>.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 7th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 7th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			We added the following services to our monitoring list: <code>Podder</code>.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We added the following services to our monitoring list: <code>Podder</code>.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 6th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 6th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			We added the following services to our monitoring list: <code>Podtrac</code>, <code
-				>Blubrry (Stats)</code
-			>,
-			<code>Podcorn</code> and
-			<code>RedCircle</code>.
-		</li>
-		<li class="pb-3 [&>code]:underline">
-			We added a monitoring location selector, allowing you to choose between global metrics or
-			region-specific ones.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We added the following services to our monitoring list: <code>Podtrac</code>, <code
+        >Blubrry (Stats)</code
+      >,
+      <code>Podcorn</code> and
+      <code>RedCircle</code>.
+    </li>
+    <li class="pb-3 [&>code]:underline">
+      We added a monitoring location selector, allowing you to choose between global metrics or
+      region-specific ones.
+    </li>
+  </ul>
 
-	<h2
-		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
-	>
-		October 5th, 2023
-	</h2>
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    October 5th, 2023
+  </h2>
 
-	<ul class="mb-4 list-outside list-disc pl-4">
-		<li class="pb-3 [&>code]:underline">
-			This is our first release, and the initial list of monitored services includes: <code
-				>Spreaker</code
-			>,
-			<code>Omny Studio</code>, <code>Megaphone</code>, <code>Buzzsprout</code>, <code>RSS.com</code
-			>,
-			<code>Spotify for Podcasters</code>, <code>Acast</code>,
-			<code>Libsyn</code>, <code>OP3.dev</code>, and <code>Chartable</code>.
-		</li>
-	</ul>
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      This is our first release, and the initial list of monitored services includes: <code
+        >Spreaker</code
+      >,
+      <code>Omny Studio</code>, <code>Megaphone</code>, <code>Buzzsprout</code>, <code>RSS.com</code
+      >,
+      <code>Spotify for Podcasters</code>, <code>Acast</code>,
+      <code>Libsyn</code>, <code>OP3.dev</code>, and <code>Chartable</code>.
+    </li>
+  </ul>
 </Layout>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -9,60 +9,81 @@ import Layout from '../layouts/Layout.astro'
 		This page contains the list of changes made to PodUptime's monitoring system and website.
 	</p>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 30th, 2023
 	</h2>
 
 	<ul class="mb-4 list-outside list-disc pl-4">
 		<li class="pb-3 [&>code]:underline">
-			For debugging purposes, we now show the full event for the last 10 issues in the detail view for each service.
+			For debugging purposes, we have implemented the display of the full event for the last 10
+			issues in the detail view for each service. This enhancement aims to assist in troubleshooting
+			and diagnosing any problems effectively.
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 27th, 2023
 	</h2>
 
 	<ul class="mb-4 list-outside list-disc pl-4">
 		<li class="pb-3 [&>code]:underline">
-			We added the following services to our monitoring list: <code>Audioboom</code> and <code>iVoox</code>.
+			We added the following services to our monitoring list: <code>Audioboom</code> and <code
+				>iVoox</code
+			>.
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 26th, 2023
 	</h2>
 
 	<ul class="mb-4 list-outside list-disc pl-4">
 		<li class="pb-3 [&>code]:underline">
-			We have released the source code of the project on <a class="underline" href="https://github.com/spreaker/poduptime">GitHub</a>.
+			We have released the source code of the project on <a
+				class="underline"
+				href="https://github.com/spreaker/poduptime">GitHub</a
+			>.
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 25th, 2023
 	</h2>
 
 	<ul class="mb-4 list-outside list-disc pl-4">
 		<li class="pb-3 [&>code]:underline">
-			In the detail view for each service we now show the instant status for each monitored <code>URL</code>.
+			In the detail view for each service we now show the instant status for each monitored <code
+				>URL</code
+			>.
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 13th, 2023
 	</h2>
 
 	<ul class="mb-4 list-outside list-disc pl-4">
 		<li class="pb-3 [&>code]:underline">
-			We've included <code>RSS feed</code> monitoring for hosting platforms. Similar to our enclosure checks, this
-			is performed with an <code>HTTP HEAD</code> request directed at the RSS feed of a dummy podcast used by our
-			monitoring service. The results of these additional checks are combined with the enclosure checks to
-			determine overall availability.
+			We've included <code>RSS feed</code> monitoring for hosting platforms. Similar to our
+			enclosure checks, this is performed with an <code>HTTP HEAD</code> request directed at the RSS
+			feed of a dummy podcast used by our monitoring service. The results of these additional checks
+			are combined with the enclosure checks to determine overall availability.
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 11th, 2023
 	</h2>
 
@@ -72,7 +93,9 @@ import Layout from '../layouts/Layout.astro'
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 10th, 2023
 	</h2>
 
@@ -87,7 +110,9 @@ import Layout from '../layouts/Layout.astro'
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 7th, 2023
 	</h2>
 
@@ -97,13 +122,17 @@ import Layout from '../layouts/Layout.astro'
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 6th, 2023
 	</h2>
 
 	<ul class="mb-4 list-outside list-disc pl-4">
 		<li class="pb-3 [&>code]:underline">
-			We added the following services to our monitoring list: <code>Podtrac</code>, <code>Blubrry (Stats)</code>,
+			We added the following services to our monitoring list: <code>Podtrac</code>, <code
+				>Blubrry (Stats)</code
+			>,
 			<code>Podcorn</code> and
 			<code>RedCircle</code>.
 		</li>
@@ -113,14 +142,19 @@ import Layout from '../layouts/Layout.astro'
 		</li>
 	</ul>
 
-	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+	<h2
+		class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+	>
 		October 5th, 2023
 	</h2>
 
 	<ul class="mb-4 list-outside list-disc pl-4">
 		<li class="pb-3 [&>code]:underline">
-			This is our first release, and the initial list of monitored services includes: <code>Spreaker</code>,
-			<code>Omny Studio</code>, <code>Megaphone</code>, <code>Buzzsprout</code>, <code>RSS.com</code>,
+			This is our first release, and the initial list of monitored services includes: <code
+				>Spreaker</code
+			>,
+			<code>Omny Studio</code>, <code>Megaphone</code>, <code>Buzzsprout</code>, <code>RSS.com</code
+			>,
 			<code>Spotify for Podcasters</code>, <code>Acast</code>,
 			<code>Libsyn</code>, <code>OP3.dev</code>, and <code>Chartable</code>.
 		</li>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -10,6 +10,16 @@ import Layout from '../layouts/Layout.astro'
 	</p>
 
 	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
+		October 30th, 2023
+	</h2>
+
+	<ul class="mb-4 list-outside list-disc pl-4">
+		<li class="pb-3 [&>code]:underline">
+			For debugging purposes, we now show the full event for the last 10 issues in the detail view for each service.
+		</li>
+	</ul>
+
+	<h2 class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100">
 		October 27th, 2023
 	</h2>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,90 +4,90 @@ import { HOSTING, PREFIXES, REGIONS } from '../lib/Constants'
 ---
 
 <Layout title="PodUptime | Real time monitoring overview">
-	<div class="flex flex-col items-start sm:flex-row sm:items-center">
-		<h2 class="flex-grow text-4xl font-bold text-pink-100">Real time monitoring</h2>
-		<select
-			id="region"
-			class="mt-2 rounded border-2 border-pink-200 bg-blue-950 px-2 py-2 text-center text-xs font-bold text-pink-200 sm:mt-0"
-		>
-			{
-				REGIONS.map((region) => {
-					return <option value={region.id}>{region.label}</option>
-				})
-			}
-		</select>
-	</div>
+  <div class="flex flex-col items-start sm:flex-row sm:items-center">
+    <h2 class="flex-grow text-4xl font-bold text-pink-100">Real time monitoring</h2>
+    <select
+      id="region"
+      class="mt-2 rounded border-2 border-pink-200 bg-blue-950 px-2 py-2 text-center text-xs font-bold text-pink-200 sm:mt-0"
+    >
+      {
+        REGIONS.map((region) => {
+          return <option value={region.id}>{region.label}</option>
+        })
+      }
+    </select>
+  </div>
 
-	<p class="pb-6 pt-4">
-		PodUptime is a distributed uptime monitoring system for the podcast industry, measuring
-		availability of hosting platforms and tracking prefixes.&nbsp;<a
-			class="underline"
-			href="/about/">Learn how we measure ↗</a
-		>
-	</p>
+  <p class="pb-6 pt-4">
+    PodUptime is a distributed uptime monitoring system for the podcast industry, measuring
+    availability of hosting platforms and tracking prefixes.&nbsp;<a
+      class="underline"
+      href="/about/">Learn how we measure ↗</a
+    >
+  </p>
 
-	<div class="flex items-baseline border-b-2 border-dotted border-pink-100 pb-2">
-		<h2 class="flex-grow text-2xl font-bold text-pink-100">Hosting Platforms</h2>
-		<span class="text-xs">last 30 minutes</span>
-	</div>
-	<ul class="pt-4">
-		{
-			HOSTING.map(({ id, label }) => {
-				return (
-					<li class="flex items-center justify-between pb-1">
-						<>
-							<a href={`/${id}`} class="hover:cursor-pointer hover:underline">
-								{label}
-							</a>
-							<div
-								id={`status-badge-${id}`}
-								class="w-24 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
-							>
-								...
-							</div>
-						</>
-					</li>
-				)
-			})
-		}
-	</ul>
-	<div class="flex items-baseline border-b-2 border-dotted border-pink-100 py-8 pb-2">
-		<h2 class="flex-grow text-2xl font-bold text-pink-100">Tracking Prefixes</h2>
-		<span class="text-xs">last 30 minutes</span>
-	</div>
-	<ul class="pt-4">
-		{
-			PREFIXES.map(({ id, label }) => {
-				return (
-					<li class="flex items-center justify-between pb-1">
-						<>
-							<a href={`/${id}`} class="hover:cursor-pointer hover:underline">
-								{label}
-							</a>
-							<div
-								id={`status-badge-${id}`}
-								class="w-24 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
-							>
-								...
-							</div>
-						</>
-					</li>
-				)
-			})
-		}
-	</ul>
+  <div class="flex items-baseline border-b-2 border-dotted border-pink-100 pb-2">
+    <h2 class="flex-grow text-2xl font-bold text-pink-100">Hosting Platforms</h2>
+    <span class="text-xs">last 30 minutes</span>
+  </div>
+  <ul class="pt-4">
+    {
+      HOSTING.map(({ id, label }) => {
+        return (
+          <li class="flex items-center justify-between pb-1">
+            <>
+              <a href={`/${id}`} class="hover:cursor-pointer hover:underline">
+                {label}
+              </a>
+              <div
+                id={`status-badge-${id}`}
+                class="w-24 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
+              >
+                ...
+              </div>
+            </>
+          </li>
+        )
+      })
+    }
+  </ul>
+  <div class="flex items-baseline border-b-2 border-dotted border-pink-100 py-8 pb-2">
+    <h2 class="flex-grow text-2xl font-bold text-pink-100">Tracking Prefixes</h2>
+    <span class="text-xs">last 30 minutes</span>
+  </div>
+  <ul class="pt-4">
+    {
+      PREFIXES.map(({ id, label }) => {
+        return (
+          <li class="flex items-center justify-between pb-1">
+            <>
+              <a href={`/${id}`} class="hover:cursor-pointer hover:underline">
+                {label}
+              </a>
+              <div
+                id={`status-badge-${id}`}
+                class="w-24 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
+              >
+                ...
+              </div>
+            </>
+          </li>
+        )
+      })
+    }
+  </ul>
 </Layout>
 
 <script>
-	import { fetchInstantData } from '../lib/Api'
-	import { updateStatusBadges } from '../lib/Ui'
+  import { fetchInstantData } from '../lib/Api'
+  import { updateStatusBadges } from '../lib/Ui'
 
-	document.getElementById('region')?.addEventListener('change', async (event) => {
-		const region = (event.target as HTMLSelectElement).value
-		updateStatusBadges([])
-		updateStatusBadges(await fetchInstantData(region))
-	})
+  document.getElementById('region')?.addEventListener('change', async (event) => {
+    const region = (event.target as HTMLSelectElement).value
+    updateStatusBadges([])
+    updateStatusBadges(await fetchInstantData(region))
+  })
 
-	// Render data for global region
-	updateStatusBadges(await fetchInstantData('global'))
+  // Render data for global region
+  updateStatusBadges(await fetchInstantData('global'))
 </script>

--- a/website/src/types.d.ts
+++ b/website/src/types.d.ts
@@ -12,3 +12,18 @@ export type Detail = {
 	timestamp: string
 	available: number | null
 }
+
+export type Issue = {
+	id: string
+	timestamp: string
+	region: string
+	endpoint: string
+	url: string
+	type: string
+	status: number
+	duration: number
+	headers: {
+		[key: string]: string
+	}
+	traversal: string[]
+}

--- a/website/src/types.d.ts
+++ b/website/src/types.d.ts
@@ -1,29 +1,29 @@
 export type Instant = {
-	endpoint: string
-	available: number | null | undefined
+  endpoint: string
+  available: number | null | undefined
 }
 
 export type ServiceInstant = {
-	type: string
-	available: number | null | undefined
+  type: string
+  available: number | null | undefined
 }
 
 export type Detail = {
-	timestamp: string
-	available: number | null
+  timestamp: string
+  available: number | null
 }
 
 export type Issue = {
-	id: string
-	timestamp: string
-	region: string
-	endpoint: string
-	url: string
-	type: string
-	status: number
-	duration: number
-	headers: {
-		[key: string]: string
-	}
-	traversal: string[]
+  id: string
+  timestamp: string
+  region: string
+  endpoint: string
+  url: string
+  type: string
+  status: number
+  duration: number
+  headers: {
+    [key: string]: string
+  }
+  traversal: string[]
 }


### PR DESCRIPTION
In this PR we completed the frontend work to display recent issues for a specific `endpoint` and `region` now that we have the [aggregation available](https://github.com/spreaker/poduptime/pull/8).

### NO ISSUES
![Screenshot 2023-10-30 alle 13 39 50](https://github.com/spreaker/poduptime/assets/49144/a895a2f0-fed2-42dd-b1aa-491e9acb9720)

### COMPACT ISSUES
![Screenshot 2023-10-30 alle 13 39 21](https://github.com/spreaker/poduptime/assets/49144/a8148de8-9634-447c-b6b2-44a6f64e70a4)

### EXPANDED ISSUE
![Screenshot 2023-10-30 alle 13 39 13](https://github.com/spreaker/poduptime/assets/49144/fb23d2ad-a951-4dc6-a1ff-39d287461c8b)

With this one we can consider this [issue](https://github.com/spreaker/poduptime/issues/2) closed. Closes #2 

