### PR TITLE
Updated API response to include generation timestamp

### DIFF
--- a/analytics/functions/aggregate-worker/handler.js
+++ b/analytics/functions/aggregate-worker/handler.js
@@ -42,7 +42,7 @@ const aggregateInstant = async function (aggregation) {
     await s3Client.send(new PutObjectCommand({
         Bucket: process.env.WEBSITE_BUCKET,
         Key: `api/instant-${region}.json`,
-        Body: JSON.stringify(result),
+        Body: JSON.stringify({ timestamp: formatISO(new Date()), data: result }),
         ContentType: "application/json"
     }));
 }
@@ -90,7 +90,7 @@ const aggregateInstantEndpoint = async function (aggregation) {
     await s3Client.send(new PutObjectCommand({
         Bucket: process.env.WEBSITE_BUCKET,
         Key: `api/instant-${endpoint}-${region}.json`,
-        Body: JSON.stringify(result),
+        Body: JSON.stringify({ timestamp: formatISO(new Date()), data: result }),
         ContentType: "application/json"
     }));
 }
@@ -150,7 +150,7 @@ const aggregateDetailed = async function (aggregation) {
     await s3Client.send(new PutObjectCommand({
         Bucket: process.env.WEBSITE_BUCKET,
         Key: `api/detailed-${endpoint}-${region}.json`,
-        Body: JSON.stringify(result),
+        Body: JSON.stringify({ timestamp: formatISO(new Date()), data: result }),
         ContentType: "application/json"
     }));
 }
@@ -179,7 +179,7 @@ const aggreateRecentIssues = async function (aggregation) {
     await s3Client.send(new PutObjectCommand({
         Bucket: process.env.WEBSITE_BUCKET,
         Key: `api/recent-issues-${endpoint}-${region}.json`,
-        Body: JSON.stringify(result),
+        Body: JSON.stringify({ timestamp: formatISO(new Date()), data: result }),
         ContentType: "application/json"
     }));
 }

--- a/website/src/lib/Api.ts
+++ b/website/src/lib/Api.ts
@@ -1,11 +1,11 @@
-import { Detail, Instant, Issue, ServiceInstant } from '../types'
+import { ApiResponse, Detail, Instant, Issue, ServiceInstant } from '../types'
 import { API_BASE_URL } from './Constants'
 
 export async function fetchInstantData(region: string): Promise<Instant[]> {
   return await fetch(`${API_BASE_URL}/api/instant-${region}.json`)
-    .then((response) => response.json() as Promise<Instant[]>)
-    .then((data) => {
-      return data
+    .then((response) => response.json() as Promise<ApiResponse<Instant[]>>)
+    .then((response) => {
+      return response.data
     })
     .catch(() => {
       return []
@@ -17,9 +17,9 @@ export async function fetchServiceInstantsData(
   region: string
 ): Promise<ServiceInstant[]> {
   return await fetch(`${API_BASE_URL}/api/instant-${endpoint}-${region}.json`)
-    .then((response) => response.json() as Promise<ServiceInstant[]>)
-    .then((data) => {
-      return data
+    .then((response) => response.json() as Promise<ApiResponse<ServiceInstant[]>>)
+    .then((response) => {
+      return response.data
     })
     .catch(() => {
       return []
@@ -28,9 +28,9 @@ export async function fetchServiceInstantsData(
 
 export async function fetchDetailedData(endpoint: string, region: string): Promise<Detail[]> {
   return await fetch(`${API_BASE_URL}/api/detailed-${endpoint}-${region}.json`)
-    .then((response) => response.json() as Promise<Detail[]>)
-    .then((data) => {
-      return data
+    .then((response) => response.json() as Promise<ApiResponse<Detail[]>>)
+    .then((response) => {
+      return response.data
     })
     .catch(() => {
       return []
@@ -39,9 +39,9 @@ export async function fetchDetailedData(endpoint: string, region: string): Promi
 
 export async function fetchRecentIssues(endpoint: string, region: string): Promise<Issue[]> {
   return await fetch(`${API_BASE_URL}/api/recent-issues-${endpoint}-${region}.json`)
-    .then((response) => response.json() as Promise<Issue[]>)
-    .then((data) => {
-      return data
+    .then((response) => response.json() as Promise<ApiResponse<Issue[]>>)
+    .then((response) => {
+      return response.data
     })
     .catch(() => {
       return []

--- a/website/src/types.d.ts
+++ b/website/src/types.d.ts
@@ -1,3 +1,8 @@
+export type ApiResponse<Type> = {
+  timestamp: string
+  data: Type
+}
+
 export type Instant = {
   endpoint: string
   available: number | null | undefined


### PR DESCRIPTION
To be able to show in the UI when the data was collected, we are changing the data structure of the API responses to wrap the data with an object where we can attach extra metadata. Since this was impacting every aggregation I also took the chance to refactor their tests a bit to remove some of the repetition.

Closes #10 