### PR TITLE
Feature: Daily View - Analytics

### DIFF
--- a/analytics/functions/aggregate-daily/handler.js
+++ b/analytics/functions/aggregate-daily/handler.js
@@ -1,0 +1,24 @@
+import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
+import config from "../../conf/config.js";
+
+const client = new SQSClient({});
+
+const scheduleAggregation = async (payload) => {
+    try {
+        await client.send(new SendMessageCommand({
+            QueueUrl: process.env.AGGREGATE_QUEUE_URL,
+            MessageBody: JSON.stringify(payload)
+        }));
+    } catch (err) {
+        console.error(`Cannot schedule aggregation`, payload, err);
+    }
+}
+
+export const aggregateDaily = async function (event, context) {
+
+    for (const region of config.regions) {
+        for (const endpoint of config.endpoints) {
+            await scheduleAggregation({ type: "daily-endpoint", region: region.id, endpoint: endpoint.id });
+        }
+    }
+}

--- a/analytics/functions/aggregate-daily/handler_test.js
+++ b/analytics/functions/aggregate-daily/handler_test.js
@@ -1,0 +1,47 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { aggregateDaily } from "./handler.js"
+import config from "../../conf/config.js";
+import { flattenDeep } from "lodash-es";
+import { use } from "../../common/fixtures.js";
+
+const expectedCalls = flattenDeep(config.regions.map((region) => {
+    return config.endpoints.map((endpoint) => {
+        return [
+            { type: "daily-endpoint", region: region.id, endpoint: endpoint.id },
+        ];
+    })
+}));
+
+describe('analytics - aggregateDaily', () => {
+
+    const sqs = use('sqs');
+
+    it('should submit jobs for each region and endpoints', async () => {
+
+        await aggregateDaily();
+
+        const calls = sqs.calls(SendMessageCommand);
+
+        assert.equal(calls.length, expectedCalls.length);
+
+        calls.forEach((call, index) => {
+
+            const args = call.args;
+            const input = args[0].input;
+
+            assert.equal(input.MessageBody, JSON.stringify(expectedCalls[index]));
+        })
+    });
+
+    it('should handle SQS errors', async (t) => {
+
+        const errorLogger = t.mock.method(console, 'error', () => { });
+        sqs.rejects('simulated error');
+
+        await aggregateDaily();
+
+        assert.equal(errorLogger.mock.calls.length, expectedCalls.length);
+    });
+});

--- a/analytics/serverless.yml
+++ b/analytics/serverless.yml
@@ -147,6 +147,18 @@ functions:
     events:
       - schedule: rate(1 minute)
 
+  aggregateDaily:
+    name: ${self:custom.appPrefix}-aggregateDaily
+    handler: functions/aggregate-daily/handler.aggregateDaily
+    timeout: 55
+    environment:
+      AGGREGATE_QUEUE_URL:
+        Fn::GetAtt:
+          - AggregateQueue
+          - QueueUrl
+    events:
+      - schedule: cron(5 0 * * ? *)
+
   aggregateWorker:
     name: ${self:custom.appPrefix}-aggregateWorker
     handler: functions/aggregate-worker/handler.aggregateWorker


### PR DESCRIPTION
The first step to provide #1 is to schedule a new aggregation running over the last 30 days of data. 

## Aggregation

An API under the route `api/daily-${endpoint}-${region}.json` is exposed to the website. The response contains a fixed number (30) of datapoints, each one representing a single day in the interval. Similarly to the `detailed` aggregation, the server ensures that the number of data points returned is the expected ones and there are no gaps. Each data point represents a day in the interval.

## Other considerations

I initially thought we should create a table storing the data in daily resolution and to have aggregations running over that table. After some `EXPLAIN`ing over the production data I reached the conclusion that's overkill since the query takes less than half a second to produce results. While it's true that we don't have an entire month worth of data yet, it doesn't look like this is going to worsen particularly over time, given that we have a sliding data retention window already implemented. We can also re-evaluate this decision later down the road.
