### PR TITLE
Add daily aggregation view

### DIFF
--- a/website/src/lib/Api.ts
+++ b/website/src/lib/Api.ts
@@ -37,6 +37,17 @@ export async function fetchDetailedData(endpoint: string, region: string): Promi
     })
 }
 
+export async function fetchDailyData(endpoint: string, region: string): Promise<Detail[]> {
+  return await fetch(`${API_BASE_URL}/api/daily-${endpoint}-${region}.json`)
+    .then((response) => response.json() as Promise<ApiResponse<Detail[]>>)
+    .then((response) => {
+      return response.data
+    })
+    .catch(() => {
+      return []
+    })
+}
+
 export async function fetchRecentIssues(endpoint: string, region: string): Promise<Issue[]> {
   return await fetch(`${API_BASE_URL}/api/recent-issues-${endpoint}-${region}.json`)
     .then((response) => response.json() as Promise<ApiResponse<Issue[]>>)
@@ -55,11 +66,13 @@ export async function fetchDetailedAndServiceInstantsAndRecentIssuesData(
   detailed: Detail[]
   instants: ServiceInstant[]
   issues: Issue[]
+  daily: Detail[]
 }> {
-  const [detailed, instants, issues] = await Promise.all([
+  const [detailed, instants, issues, daily] = await Promise.all([
     fetchDetailedData(endpoint, region),
     fetchServiceInstantsData(endpoint, region),
-    fetchRecentIssues(endpoint, region)
+    fetchRecentIssues(endpoint, region),
+    fetchDailyData(endpoint, region)
   ])
-  return { detailed, instants, issues }
+  return { detailed, instants, issues, daily }
 }

--- a/website/src/lib/Ui.ts
+++ b/website/src/lib/Ui.ts
@@ -33,6 +33,14 @@ const getStatus = (available: number | null | undefined) => {
   return 'PARTIAL'
 }
 
+const getAvailabilityPercentage = (available: number | null | undefined) => {
+  if (typeof available === 'undefined') return '...'
+  if (available === null) return 'Unknown Availability'
+  if (available === 0) return '0% Availability'
+  if (available === 1) return '100% Availability'
+  return `${(available * 100).toFixed(3)}% Availability`
+}
+
 function updateBadge(
   element: HTMLElement | undefined | null,
   available: number | null | undefined
@@ -106,7 +114,7 @@ export function updateDailyGrid(data: Detail[]) {
         year: 'numeric',
         month: 'numeric',
         day: 'numeric'
-      }).format(new Date(item.timestamp))}`
+      }).format(new Date(item.timestamp))} ${getAvailabilityPercentage(item.available)}`
     }
   })
 }

--- a/website/src/lib/Ui.ts
+++ b/website/src/lib/Ui.ts
@@ -78,6 +78,39 @@ export function updateStatusBadges(data: Instant[]) {
   })
 }
 
+export function updateDailyGrid(data: Detail[]) {
+  if (data.length === 0) {
+    for (let i = 0; i < 30; i++) {
+      const cell = document.getElementById(`daily-cell-${i}`)
+      const cellText = document.getElementById(`daily-cell-text-${i}`)
+      if (cell && cellText) {
+        cell.classList.remove(
+          ...DETAIL_CELL_CLASSES['UNKNOWN'],
+          ...DETAIL_CELL_CLASSES['UP'],
+          ...DETAIL_CELL_CLASSES['DOWN'],
+          ...DETAIL_CELL_CLASSES['PARTIAL'],
+          ...DETAIL_CELL_CLASSES['LOADING']
+        )
+        cell.classList.add(...DETAIL_CELL_CLASSES['LOADING'])
+        cellText.innerText = `...`
+      }
+    }
+  }
+  data.forEach((item, i) => {
+    const cell = document.getElementById(`daily-cell-${i}`)
+    const cellText = document.getElementById(`daily-cell-text-${i}`)
+    if (cell && cellText) {
+      cell.classList.remove(...DETAIL_CELL_CLASSES['LOADING'])
+      cell.classList.add(...DETAIL_CELL_CLASSES[getStatus(item.available)])
+      cellText.innerText = `${new Intl.DateTimeFormat('default', {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric'
+      }).format(new Date(item.timestamp))}`
+    }
+  })
+}
+
 export function updateDetailedGrid(data: Detail[]) {
   if (data.length === 0) {
     for (let i = 0; i < 1440; i++) {

--- a/website/src/pages/[endpoint].astro
+++ b/website/src/pages/[endpoint].astro
@@ -2,14 +2,18 @@
 import Layout from '../layouts/Layout.astro'
 import { MONITORED, REGIONS } from '../lib/Constants'
 
-const MATRIX: number[][] = []
-
+const LAST_24_HOURS: number[][] = []
 for (let i = 0; i < 24; i++) {
   let ROW: number[] = []
   for (let j = 0; j < 60; j++) {
     ROW.push(1)
   }
-  MATRIX.push(ROW)
+  LAST_24_HOURS.push(ROW)
+}
+
+const LAST_30_DAYS: number[] = []
+for (let i = 0; i < 30; i++) {
+  LAST_30_DAYS.push(1)
 }
 
 export function getStaticPaths() {
@@ -84,7 +88,7 @@ const endpointServices = MONITORED[endpointId || ''].services
   <table class="mt-4 w-full opacity-80">
     <tbody>
       {
-        MATRIX.map((row, i) => {
+        LAST_24_HOURS.map((row, i) => {
           return (
             <tr>
               {row.map((col, j) => (
@@ -146,6 +150,70 @@ const endpointServices = MONITORED[endpointId || ''].services
     </li>
   </ul>
   <div class="flex items-baseline border-b-2 border-dotted border-pink-100 pt-6">
+    <h2 class="flex-grow pb-2 text-2xl font-bold text-pink-100">Daily Status</h2>
+    <span class="text-xs">last 30 days</span>
+  </div>
+  <table class="mt-4 w-full opacity-80">
+    <tbody>
+      <tr>
+        {
+          LAST_30_DAYS.map((_, i) => {
+            return (
+              <td
+                id={`daily-cell-${i}`}
+                class={[
+                  'bg-gray-500',
+                  'hover:bg-gray-300',
+                  'text-white',
+                  'border',
+                  'border-transparent',
+                  'h-5',
+                  'sm:h-6',
+                  'aspect-square',
+                  'group',
+                  'transition-colors',
+                  'duration-500',
+                  'relative'
+                ].join(' ')}
+              >
+                <span
+                  id={`daily-cell-text-${i}`}
+                  class="absolute top-4 z-10 hidden rounded bg-zinc-950 px-3 py-2 text-xs font-thin group-hover:block"
+                >
+                  ...
+                </span>
+              </td>
+            )
+          })
+        }
+      </tr>
+    </tbody>
+  </table>
+  <ul class="grid grid-cols-2 pt-1 sm:flex">
+    <li>
+      <span class="mr-2 inline-block h-3 w-3 bg-lime-500"></span><span class="pr-2 text-xs">UP</span
+      >
+    </li>
+    <li>
+      <span class="mr-2 inline-block h-3 w-3 bg-yellow-500"></span><span class="pr-2 text-xs"
+        >PARTIAL</span
+      >
+    </li>
+    <li>
+      <span class="mr-2 inline-block h-3 w-3 bg-red-500"></span><span class="pr-2 text-xs"
+        >DOWN</span
+      >
+    </li>
+    <li>
+      <span class="mr-2 inline-block h-3 w-3 bg-gray-500"></span><span class="pr-2 text-xs"
+        >UNKNOWN</span
+      >
+    </li>
+    <li class="sm:ml-auto">
+      <a class="text-xs underline" href="/about/">Learn more ↗</a>
+    </li>
+  </ul>
+  <div class="flex items-baseline border-b-2 border-dotted border-pink-100 pt-6">
     <h2 class="flex-grow pb-2 text-2xl font-bold text-pink-100">Recent Issues</h2>
     <span class="text-xs">10 most recent</span>
   </div>
@@ -154,7 +222,12 @@ const endpointServices = MONITORED[endpointId || ''].services
 
 <script>
   import { fetchDetailedAndServiceInstantsAndRecentIssuesData } from '../lib/Api'
-  import { updateDetailedGrid, updateServiceStatusBadges, updateRecentIssues } from '../lib/Ui'
+  import {
+    updateDetailedGrid,
+    updateServiceStatusBadges,
+    updateRecentIssues,
+    updateDailyGrid
+  } from '../lib/Ui'
 
   const vars = JSON.parse(document.getElementById('data')?.dataset.vars || '{}')
   const endpointId = vars.id || ''
@@ -162,24 +235,23 @@ const endpointServices = MONITORED[endpointId || ''].services
   document.getElementById('region')?.addEventListener('change', async (event) => {
     const region = (event.target as HTMLSelectElement).value
     updateDetailedGrid([])
+    updateDailyGrid([])
     updateServiceStatusBadges(endpointId, [])
     updateRecentIssues(null)
-    const { instants, detailed, issues } = await fetchDetailedAndServiceInstantsAndRecentIssuesData(
-      endpointId,
-      region
-    )
+    const { instants, detailed, issues, daily } =
+      await fetchDetailedAndServiceInstantsAndRecentIssuesData(endpointId, region)
     updateDetailedGrid(detailed)
     updateServiceStatusBadges(endpointId, instants)
     updateRecentIssues(issues)
+    updateDailyGrid(daily)
   })
 
   // Render data for global region
-  const { instants, detailed, issues } = await fetchDetailedAndServiceInstantsAndRecentIssuesData(
-    endpointId,
-    'global'
-  )
+  const { instants, detailed, issues, daily } =
+    await fetchDetailedAndServiceInstantsAndRecentIssuesData(endpointId, 'global')
 
   updateDetailedGrid(detailed)
   updateServiceStatusBadges(endpointId, instants)
   updateRecentIssues(issues)
+  updateDailyGrid(daily)
 </script>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -12,6 +12,20 @@ import Layout from '../layouts/Layout.astro'
   <h2
     class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
   >
+    October 31th, 2023
+  </h2>
+
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We implemented an aggregated daily view over the last 30 days for each monitored platform. The
+      value displayed for each day is the aggregation of all data points generated from each
+      monitored url of the platform.
+    </li>
+  </ul>
+
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
     October 30th, 2023
   </h2>
 


### PR DESCRIPTION
Create an aggregated daily view over the last 30 days for each monitored platform. The value displayed for each day is the aggregation of all data points generated from each monitored url of the platform. Closes #1 

<img width="572" alt="Screenshot 2023-10-31 alle 11 55 00" src="https://github.com/spreaker/poduptime/assets/49144/629e305a-3044-4d70-b09d-97dc3f12ba43">
