### PR TITLE
Enrich measurement event with error details

### DIFF
--- a/analytics/deployment/resources/athena.yml
+++ b/analytics/deployment/resources/athena.yml
@@ -65,3 +65,5 @@ Resources:
               Type: string
             - Name: traversal
               Type: string
+            - Name: error
+              Type: string

--- a/monitor/common/errors.js
+++ b/monitor/common/errors.js
@@ -1,0 +1,43 @@
+
+class GenericError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'GenericError';
+        this.code = 'ERROR_GENERIC';
+    }
+}
+
+export class UnexpectedRedirectLocationError extends GenericError {
+    constructor(location) {
+        const message = `Unexpected Redirect Location: ${location}`;
+        super(message);
+        Error.captureStackTrace(this, UnexpectedRedirectLocationError);
+        this.name = 'UnexpectedRedirectLocationError';
+        this.message = message;
+        this.code = 'ERROR_UNEXPECTED_REDIRECT_LOCATION';
+    }
+}
+
+export class UnexpectedHttpStatusError extends GenericError {
+    constructor(status) {
+        const message = `Unexpected HTTP Status: ${status}`;
+        super(message);
+        Error.captureStackTrace(this, UnexpectedHttpStatusError);
+        this.name = 'UnexpectedHttpStatusError';
+        this.message = message;
+        this.code = 'ERROR_UNEXPECTED_HTTP_STATUS';
+    }
+}
+
+export const serializeError = function (error) {
+
+    if (!error) {
+        return null;
+    }
+
+    return {
+        name: error.name,
+        code: error.code,
+        message: error.message
+    }
+}

--- a/monitor/functions/check-endpoint/handler.js
+++ b/monitor/functions/check-endpoint/handler.js
@@ -16,6 +16,19 @@ const createAgent = function (options) {
     return new Agent(options);
 }
 
+const serializeError = function (error) {
+
+    if (!error) {
+        return null;
+    }
+
+    return {
+        name: error.name,
+        code: error.code,
+        message: error.message
+    }
+}
+
 const performCheck = async function (service, agentFactory) {
 
     const result = {
@@ -48,7 +61,7 @@ const performCheck = async function (service, agentFactory) {
         connect: { timeout: 5000 },
     });
 
-    let statusCode = 0, headers = null, context = null;
+    let statusCode = 0, headers = null, context = null, error = null;
 
     const start = hrtime.bigint();
 
@@ -59,6 +72,7 @@ const performCheck = async function (service, agentFactory) {
             headers: { "User-Agent": `Mozilla/5.0 (compatible; PodUptimeBot/1.0; +https://poduptime.com; rid:${result.id})` },
         }));
     } catch (e) {
+        error = e;
         console.error("Check endpoint error", result, e);
     }
 
@@ -90,7 +104,8 @@ const performCheck = async function (service, agentFactory) {
         duration: durationMs,
         headers: headers,
         traversal: traversal,
-        available: available ? 1 : 0
+        available: available ? 1 : 0,
+        error: serializeError(error)
     };
 }
 

--- a/monitor/functions/check-endpoint/handler.js
+++ b/monitor/functions/check-endpoint/handler.js
@@ -3,6 +3,7 @@ import { PutEventsCommand, EventBridgeClient } from "@aws-sdk/client-eventbridge
 import { formatISO } from 'date-fns';
 import { request, Agent } from 'undici';
 import { URL } from 'node:url';
+import { UnexpectedRedirectLocationError, UnexpectedHttpStatusError, serializeError } from "../../common/errors.js";
 
 const { randomUUID } = await import('node:crypto');
 
@@ -16,29 +17,7 @@ const createAgent = function (options) {
     return new Agent(options);
 }
 
-const serializeError = function (error) {
-
-    if (!error) {
-        return null;
-    }
-
-    return {
-        name: error.name,
-        code: error.code,
-        message: error.message
-    }
-}
-
-const performCheck = async function (service, agentFactory) {
-
-    const result = {
-        id: randomUUID(),
-        timestamp: formatISO(new Date()),
-        region: process.env.AWS_REGION,
-        endpoint: service.endpoint,
-        url: service.url,
-        type: service.type
-    };
+const performHTTPRequest = async function (id, service, agentFactory) {
 
     /**
      * HTTP Connection lifecycle
@@ -66,46 +45,73 @@ const performCheck = async function (service, agentFactory) {
     const start = hrtime.bigint();
 
     try {
-        ({ statusCode, headers, context } = await request(result.url, {
+        ({ statusCode, headers, context } = await request(service.url, {
             dispatcher: agent,
             method: 'HEAD',
-            headers: { "User-Agent": `Mozilla/5.0 (compatible; PodUptimeBot/1.0; +https://poduptime.com; rid:${result.id})` },
+            headers: { "User-Agent": `Mozilla/5.0 (compatible; PodUptimeBot/1.0; +https://poduptime.com; rid:${id})` },
         }));
     } catch (e) {
         error = e;
-        console.error("Check endpoint error", result, e);
+        console.error("Check endpoint error", service, e);
     }
 
-    const durationMs = getDurationMs(start);
+    const duration = getDurationMs(start);
 
     try {
         await agent.destroy();
     } catch (e) { }
 
-    const traversal = (context?.history ?? [new URL(result.url)]).map((u) => {
+    const traversal = (context?.history ?? [new URL(service.url)]).map((u) => {
         return u.href;
     });
 
-    /**
-     * Availability is defined differently based on the endpoint type.
-     *
-     * - Prefix endpoints are considered available when they redirect to
-     *   the expected url
-     * - Other endpoints are considered available when they respond with
-     *   an HTTP 200 status code
-     */
-    const available = "prefix" !== service.type ? statusCode === 200 :
-        [301, 302, 303, 307, 308].includes(statusCode) &&
-        service.expected_url === headers["location"];
+    return {
+        status: statusCode, headers, error, traversal, duration
+    };
+}
+
+const determineAvailability = function (service, response) {
+
+    // If HTTP request triggered an error, we let it bubble
+    if (response.error) {
+        return { available: 0, error: serializeError(response.error) };
+    }
+
+    // Prefix service must redirect
+    if ("prefix" === service.type && ![301, 302, 303, 307, 308].includes(response.status)) {
+        return { available: 0, error: serializeError(new UnexpectedHttpStatusError(response.status)) };
+    }
+
+    // Prefix service must redirect to the expected location
+    if ("prefix" === service.type && service.expected_url !== response.headers["location"]) {
+        return { available: 0, error: serializeError(new UnexpectedRedirectLocationError(response.headers["location"])) };
+    }
+
+    // Other services should return 200
+    if ("prefix" !== service.type && response.status !== 200) {
+        return { available: 0, error: serializeError(new UnexpectedHttpStatusError(response.status)) };
+    }
+
+    return { available: 1, error: null };
+}
+
+const performCheck = async function (service, agentFactory) {
+
+    const result = {
+        id: randomUUID(),
+        timestamp: formatISO(new Date()),
+        region: process.env.AWS_REGION,
+        endpoint: service.endpoint,
+        url: service.url,
+        type: service.type
+    };
+
+    const response = await performHTTPRequest(result.id, service, agentFactory);
 
     return {
         ...result,
-        status: statusCode,
-        duration: durationMs,
-        headers: headers,
-        traversal: traversal,
-        available: available ? 1 : 0,
-        error: serializeError(error)
+        ...response,
+        ...determineAvailability(service, response)
     };
 }
 


### PR DESCRIPTION
For effective troubleshooting, it's important to understand why a certain measurement was reported as unavailable. With this PR I'm introducing a new `error` field in the event json containing the details about what went wrong.

For example, an unexpected HTTP status code will produce:

```js
error: {
  name: 'UnexpectedHttpStatusError',
  code: 'ERROR_UNEXPECTED_HTTP_STATUS',
  message: 'Unexpected HTTP Status: 404'
}
```

While a redirect to the wrong location will produce:

```js
error: {
  name: 'UnexpectedRedirectLocationError',
  code: 'ERROR_UNEXPECTED_REDIRECT_LOCATION',
  message: 'Unexpected Redirect Location: https://poduptime.com/wrong.mp3'
}
```

Closes #17 