### PR TITLE
Add GitHub link and improve issue list rendering

### DIFF
--- a/website/public/github-corner-right.svg
+++ b/website/public/github-corner-right.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 250 250" fill-opacity="1" style="position: absolute; top: 0; right: 0">
+  <path d="M0 0l115 115h15l12 27 108 108V0z" fill="#60a5fa" fill-opacity="0.4"/>
+  <path class="octo-arm" d="M128 109c-15-9-9-19-9-19 3-7 2-11 2-11-1-7 3-2 3-2 4 5 2 11 2 11-3 10 5 15 9 16" style="-webkit-transform-origin: 130px 106px; transform-origin: 130px 106px"/>
+  <path class="octo-body" d="M115 115s4 2 5 0l14-14c3-2 6-3 8-3-8-11-15-24 2-41 5-5 10-7 16-7 1-2 3-7 12-11 0 0 5 3 7 16 4 2 8 5 12 9s7 8 9 12c14 3 17 7 17 7-4 8-9 11-11 11 0 6-2 11-7 16-16 16-30 10-41 2 0 3-1 7-5 11l-12 11c-1 1 1 5 1 5z"/>
+</svg>

--- a/website/public/github-corner-right.svg
+++ b/website/public/github-corner-right.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 250 250" fill-opacity="1" style="position: absolute; top: 0; right: 0">
-  <path d="M0 0l115 115h15l12 27 108 108V0z" fill="#60a5fa" fill-opacity="0.4"/>
+  <path d="M0 0l115 115h15l12 27 108 108V0z" fill="#20337D" fill-opacity="0.9"/>
   <path class="octo-arm" d="M128 109c-15-9-9-19-9-19 3-7 2-11 2-11-1-7 3-2 3-2 4 5 2 11 2 11-3 10 5 15 9 16" style="-webkit-transform-origin: 130px 106px; transform-origin: 130px 106px"/>
   <path class="octo-body" d="M115 115s4 2 5 0l14-14c3-2 6-3 8-3-8-11-15-24 2-41 5-5 10-7 16-7 1-2 3-7 12-11 0 0 5 3 7 16 4 2 8 5 12 9s7 8 9 12c14 3 17 7 17 7-4 8-9 11-11 11 0 6-2 11-7 16-16 16-30 10-41 2 0 3-1 7-5 11l-12 11c-1 1 1 5 1 5z"/>
 </svg>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -44,6 +44,17 @@ const canonicalURL = Astro.site ? new URL(Astro.url.pathname, Astro.site) : null
               src="/logo.jpg"
               alt="PodUptime, podcast uptime monitoring for the podcast industry"
             />
+            <a
+              href="https://github.com/spreaker/poduptime#poduptime"
+              target="_blank"
+              rel="noopener"
+            >
+              <img
+                src="/github-corner-right.svg"
+                class="absolute right-1 top-1 h-20 w-20 rounded-tr-lg"
+                alt="GitHub"
+              />
+            </a>
           </a>
           <div
             class="items-top relative flex justify-start space-x-6 rounded-lg bg-white ring-1 ring-gray-900/5"

--- a/website/src/lib/Ui.ts
+++ b/website/src/lib/Ui.ts
@@ -161,6 +161,10 @@ export function updateDetailedGrid(data: Detail[]) {
   })
 }
 
+function padCenter(str, maxLen, padChar = '\xa0') {
+  return str.padStart((str.length + maxLen) / 2, padChar).padEnd(maxLen, padChar)
+}
+
 function renderIssue(issue: Issue) {
   return `
 		<li class="pt-1">
@@ -177,7 +181,7 @@ function renderIssue(issue: Issue) {
           hour: '2-digit',
           minute: '2-digit',
           second: '2-digit'
-        }).format(new Date(issue.timestamp))} | ${issue.type.padEnd(9, '_')} | ${issue.region}
+        }).format(new Date(issue.timestamp))} |${padCenter(issue.type, 11)}| ${issue.region}
         </code>
 			</div>
 			<pre id="issue-detail-${issue.id}" class="text-xs hidden pt-1 overflow-x-scroll">${JSON.stringify(

--- a/website/src/lib/Ui.ts
+++ b/website/src/lib/Ui.ts
@@ -168,14 +168,17 @@ function renderIssue(issue: Issue) {
 				onclick="document.getElementById('${`issue-detail-${issue.id}`}').classList.toggle('hidden')"
 				class="underline cursor-pointer text-sm"
 			>
+        <code class="rounded px-2 py-1 text-xs font-bold">
 				${new Intl.DateTimeFormat('default', {
-          year: 'numeric',
-          month: 'numeric',
-          day: 'numeric',
-          minute: 'numeric',
-          hour: 'numeric',
-          timeZone: 'UTC'
-        }).format(new Date(issue.timestamp))} | ${issue.type} | ${issue.region}
+          timeZone: 'UTC',
+          year: '2-digit',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit'
+        }).format(new Date(issue.timestamp))} | ${issue.type.padEnd(9, '_')} | ${issue.region}
+        </code>
 			</div>
 			<pre id="issue-detail-${issue.id}" class="text-xs hidden pt-1 overflow-x-scroll">${JSON.stringify(
         issue,


### PR DESCRIPTION
Some minor UI improvements:

- a link in the header to this github repo
<img width="813" alt="Screenshot 2023-11-02 alle 09 06 20" src="https://github.com/spreaker/poduptime/assets/49144/1c41c828-874e-4446-90c7-b846f4421547">

- an improved rendering for issues list to make it more readable
<img width="700" alt="Screenshot 2023-11-02 alle 09 07 58" src="https://github.com/spreaker/poduptime/assets/49144/7cfd145a-3cc1-4629-a01d-3ff1bba36af9">
