### PR TITLE
Define failure modes for Lambdas

### DIFF
--- a/analytics/deployment/resources/events.yml
+++ b/analytics/deployment/resources/events.yml
@@ -3,3 +3,22 @@ Resources:
     Type: AWS::Events::EventBus
     Properties:
       Name: ${self:custom.appPrefix}-${opt:stage}-main
+  SendToSQSArchiveEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventBusName: !Ref MainEventBus
+      EventPattern:
+        source:
+          - monitor
+      State: ENABLED
+      Targets:
+        - Id: send-to-sqs-archive-raw
+          Arn:
+            Fn::GetAtt:
+              - ArchiveRawQueue
+              - Arn
+        - Id: send-to-sqs-archive-database
+          Arn:
+            Fn::GetAtt:
+              - ArchiveDatabaseQueue
+              - Arn

--- a/analytics/deployment/resources/sqs.yml
+++ b/analytics/deployment/resources/sqs.yml
@@ -4,6 +4,33 @@ Resources:
     Properties:
       QueueName: ${self:custom.appPrefix}-${opt:stage}-blackhole
       MessageRetentionPeriod: 60
+  ArchiveDeadletterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: ${self:custom.appPrefix}-${opt:stage}-archive-deadletter
+      MessageRetentionPeriod: 604800
+  ArchiveRawQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: ${self:custom.appPrefix}-${opt:stage}-archive-raw
+      VisibilityTimeout: 60
+      RedrivePolicy:
+        maxReceiveCount: 5
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - ArchiveDeadletterQueue
+            - Arn
+  ArchiveDatabaseQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: ${self:custom.appPrefix}-${opt:stage}-archive-database
+      VisibilityTimeout: 60
+      RedrivePolicy:
+        maxReceiveCount: 5
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - ArchiveDeadletterQueue
+            - Arn
   AggregateQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/analytics/deployment/resources/sqs.yml
+++ b/analytics/deployment/resources/sqs.yml
@@ -20,6 +20,21 @@ Resources:
           Fn::GetAtt:
             - ArchiveDeadletterQueue
             - Arn
+  ArchiveRawQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: events.amazonaws.com
+          Action: SQS:SendMessage
+          Resource:
+            Fn::GetAtt:
+              - ArchiveRawQueue
+              - Arn
+      Queues:
+        - Ref: ArchiveRawQueue
   ArchiveDatabaseQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -31,6 +46,21 @@ Resources:
           Fn::GetAtt:
             - ArchiveDeadletterQueue
             - Arn
+  ArchiveDatabaseQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: events.amazonaws.com
+          Action: SQS:SendMessage
+          Resource:
+            Fn::GetAtt:
+              - ArchiveDatabaseQueue
+              - Arn
+      Queues:
+        - Ref: ArchiveDatabaseQueue
   AggregateQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/analytics/deployment/resources/sqs.yml
+++ b/analytics/deployment/resources/sqs.yml
@@ -1,6 +1,17 @@
 Resources:
+  BlackholeDeadletterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: ${self:custom.appPrefix}-${opt:stage}-blackhole
+      MessageRetentionPeriod: 60
   AggregateQueue:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: ${self:custom.appPrefix}-${opt:stage}-aggregate
       VisibilityTimeout: 60
+      RedrivePolicy:
+        maxReceiveCount: 1
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - BlackholeDeadletterQueue
+            - Arn

--- a/analytics/functions/aggregate-daily/handler.js
+++ b/analytics/functions/aggregate-daily/handler.js
@@ -21,13 +21,9 @@ export const aggregateDaily = async function (event, context) {
     })).map(buildAggregationMessage);
 
     for (const batch of chunk(messages, 10)) {
-        try {
-            await client.send(new SendMessageBatchCommand({
-                QueueUrl: process.env.AGGREGATE_QUEUE_URL,
-                Entries: batch
-            }));
-        } catch (err) {
-            console.error(`Cannot schedule aggregation batch`, batch, err);
-        }
+        await client.send(new SendMessageBatchCommand({
+            QueueUrl: process.env.AGGREGATE_QUEUE_URL,
+            Entries: batch
+        }));
     }
 }

--- a/analytics/functions/aggregate-daily/handler_test.js
+++ b/analytics/functions/aggregate-daily/handler_test.js
@@ -5,6 +5,7 @@ import { aggregateDaily } from "./handler.js"
 import config from "../../conf/config.js";
 import { flattenDeep } from "lodash-es";
 import { use } from "../../common/fixtures.js";
+import { throwsAsync } from '../../common/assert.js'
 
 const expectedMessages = flattenDeep(config.regions.map((region) => {
     return config.endpoints.map((endpoint) => {
@@ -32,13 +33,10 @@ describe('analytics - aggregateDaily', () => {
         assert.deepStrictEqual(expectedMessages, actualMessages);
     });
 
-    it('should handle SQS errors', async (t) => {
+    it('should throw on SQS errors', async (t) => {
 
-        const errorLogger = t.mock.method(console, 'error', () => { });
         sqs.rejects('simulated error');
 
-        await aggregateDaily();
-
-        assert.equal(errorLogger.mock.calls.length, Math.ceil(expectedMessages.length / 10));
+        await throwsAsync(aggregateDaily());
     });
 });

--- a/analytics/functions/aggregate-minutely/handler.js
+++ b/analytics/functions/aggregate-minutely/handler.js
@@ -25,13 +25,9 @@ export const aggregateMinutely = async function (event, context) {
     })).map(buildAggregationMessage);
 
     for (const batch of chunk(messages, 10)) {
-        try {
-            await client.send(new SendMessageBatchCommand({
-                QueueUrl: process.env.AGGREGATE_QUEUE_URL,
-                Entries: batch
-            }));
-        } catch (err) {
-            console.error(`Cannot schedule aggregation batch`, batch, err);
-        }
+        await client.send(new SendMessageBatchCommand({
+            QueueUrl: process.env.AGGREGATE_QUEUE_URL,
+            Entries: batch
+        }));
     }
 }

--- a/analytics/functions/aggregate-minutely/handler_test.js
+++ b/analytics/functions/aggregate-minutely/handler_test.js
@@ -5,6 +5,7 @@ import { aggregateMinutely } from "./handler.js"
 import config from "../../conf/config.js";
 import { flattenDeep } from "lodash-es";
 import { use } from "../../common/fixtures.js";
+import { throwsAsync } from '../../common/assert.js'
 
 const expectedMessages = flattenDeep(config.regions.map((region) => {
     return [
@@ -38,13 +39,10 @@ describe('analytics - aggregateMinutely', () => {
         assert.deepStrictEqual(expectedMessages, actualMessages);
     });
 
-    it('should handle SQS errors', async (t) => {
+    it('should throw SQS errors', async (t) => {
 
-        const errorLogger = t.mock.method(console, 'error', () => { });
         sqs.rejects('simulated error');
 
-        await aggregateMinutely();
-
-        assert.equal(errorLogger.mock.calls.length, Math.ceil(expectedMessages.length / 10));
+        await throwsAsync(aggregateMinutely());
     });
 });

--- a/analytics/serverless.yml
+++ b/analytics/serverless.yml
@@ -111,7 +111,16 @@ resources:
   - ${file(deployment/resources/sqs.yml)}
 
 functions:
-
+  #
+  # Function: archiveRaw
+  # Purpose: archive a raw copy of the incoming measurement event
+  #   on S3 for troubleshooting purposes and re-ingestion
+  # Failure mode:  This function is invoked by the Lambda/SQS poller
+  #   so its retry policy is managed by the SQS queue configuration. In this
+  #   specific case, it's setup to allow for 5 deliveries and then move the
+  #   message to a DLQ that hold the messages for a week to allow for a redrive
+  #
+  # TODO switch to SQS in a separate PR to avoid data loss
   archiveRaw:
     name: ${self:custom.appPrefix}-archiveRaw
     handler: functions/archive-raw/handler.archiveRaw
@@ -124,7 +133,16 @@ functions:
           pattern:
             source:
               - monitor
-
+  #
+  # Function: archiveDatabase
+  # Purpose: archive a the measurement event in Aurora to be used by
+  #   the aggregation tasks
+  # Failure mode:  This function is invoked by the Lambda/SQS poller
+  #   so its retry policy is managed by the SQS queue configuration. In this
+  #   specific case, it's setup to allow for 5 deliveries and then move the
+  #   message to a DLQ that hold the messages for a week to allow for a redrive
+  #
+  # TODO switch to SQS in a separate PR to avoid data loss
   archiveDatabase:
     name: ${self:custom.appPrefix}-archiveDatabase
     handler: functions/archive-database/handler.archiveDatabase

--- a/analytics/serverless.yml
+++ b/analytics/serverless.yml
@@ -180,7 +180,15 @@ functions:
     events:
       - schedule: cron(5 0 * * ? *)
     maximumRetryAttempts: 5
-
+  #
+  # Function: aggregateWorker
+  # Purpose: perform a single aggregation job and save the results
+  #   on S3
+  # Failure mode:  This function is invoked by the Lambda/SQS poller
+  #   so its retry policy is managed by the SQS queue configuration. In this
+  #   specific case, it's setup to allow for single delivery and then move the
+  #   message to a blackhole DLQ that evicts them fast and we'd never redrive.
+  #
   aggregateWorker:
     name: ${self:custom.appPrefix}-aggregateWorker
     handler: functions/aggregate-worker/handler.aggregateWorker

--- a/analytics/serverless.yml
+++ b/analytics/serverless.yml
@@ -135,7 +135,17 @@ functions:
           pattern:
             source:
               - monitor
-
+  #
+  # Function: aggregateMinutely
+  # Purpose: kickstart aggregation jobs that are supposed to run
+  #   on a minutely schedule
+  # Failure mode: This function is invoked async from EventBridge so its retry
+  #   policy is managed with maximumRetryAttempts/onFailure. In this
+  #   specific case being this function re-triggered every minute from
+  #   a scheduled event, we're NOT going to perform any retry in case
+  #   this function fail and we don't need the initial event to be
+  #   delivered to a DLQ
+  #
   aggregateMinutely:
     name: ${self:custom.appPrefix}-aggregateMinutely
     handler: functions/aggregate-minutely/handler.aggregateMinutely
@@ -147,7 +157,17 @@ functions:
           - QueueUrl
     events:
       - schedule: rate(1 minute)
-
+    maximumRetryAttempts: 0
+  #
+  # Function: aggregateDaily
+  # Purpose: kickstart aggregation jobs that are supposed to run
+  #   on a daily schedule
+  # Failure mode: This function is invoked async from EventBridge so its retry
+  #   policy is managed with maximumRetryAttempts/onFailure. In this
+  #   specific case to avoid waiting until the next day to have it triggered
+  #   again we allow for a few retries but we don't need the initial event to be
+  #   delivered to a DLQ
+  #
   aggregateDaily:
     name: ${self:custom.appPrefix}-aggregateDaily
     handler: functions/aggregate-daily/handler.aggregateDaily
@@ -159,6 +179,7 @@ functions:
           - QueueUrl
     events:
       - schedule: cron(5 0 * * ? *)
+    maximumRetryAttempts: 5
 
   aggregateWorker:
     name: ${self:custom.appPrefix}-aggregateWorker
@@ -174,9 +195,19 @@ functions:
             Fn::GetAtt:
               - AggregateQueue
               - Arn
-
+  #
+  # Function: cleanupDatabase
+  # Purpose: implement database retention period by deleting rows falling
+  #   out of the retention window.
+  # Failure mode: This function is invoked async from EventBridge so its retry
+  #   policy is managed with maximumRetryAttempts/onFailure. In this
+  #   specific case to avoid waiting until the next day to have it triggered
+  #   again we allow for a few retries but we don't need the initial event to be
+  #   delivered to a DLQ
+  #
   cleanupDatabase:
     name: ${self:custom.appPrefix}-cleanupDatabase
     handler: functions/cleanup-database/handler.cleanupDatabase
     events:
       - schedule: rate(1 day)
+    maximumRetryAttempts: 5

--- a/analytics/serverless.yml
+++ b/analytics/serverless.yml
@@ -179,7 +179,7 @@ functions:
           - QueueUrl
     events:
       - schedule: cron(5 0 * * ? *)
-    maximumRetryAttempts: 5
+    maximumRetryAttempts: 2
   #
   # Function: aggregateWorker
   # Purpose: perform a single aggregation job and save the results
@@ -218,4 +218,4 @@ functions:
     handler: functions/cleanup-database/handler.cleanupDatabase
     events:
       - schedule: rate(1 day)
-    maximumRetryAttempts: 5
+    maximumRetryAttempts: 2

--- a/monitor/common/assert.js
+++ b/monitor/common/assert.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+
+export const throwsAsync = async function (promise, error) {
+    let f = () => { };
+    try {
+        await promise;
+    } catch (e) {
+        f = () => { throw e };
+    } finally {
+        assert.throws(f, error);
+    }
+}

--- a/monitor/deployment/resources/sqs.yml
+++ b/monitor/deployment/resources/sqs.yml
@@ -1,5 +1,16 @@
 Resources:
+  BlackholeDeadletterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: ${self:custom.appPrefix}-${opt:stage}-blackhole
+      MessageRetentionPeriod: 60
   CheckEndpointQueue:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: ${self:custom.appPrefix}-${opt:stage}-check-endpoint
+      RedrivePolicy:
+        maxReceiveCount: 1
+        deadLetterTargetArn:
+          Fn::GetAtt:
+            - BlackholeDeadletterQueue
+            - Arn

--- a/monitor/functions/check-endpoint/handler.js
+++ b/monitor/functions/check-endpoint/handler.js
@@ -120,16 +120,12 @@ export const checkEndpoint = async function (event, context) {
     const service = JSON.parse(event.Records[0].body);
     const result = await performCheck(service, context?.agentFactory ?? createAgent);
 
-    try {
-        await client.send(new PutEventsCommand({
-            Entries: [{
-                EventBusName: process.env.EVENT_BUS,
-                Source: 'monitor',
-                DetailType: "measurement",
-                Detail: JSON.stringify(result)
-            }]
-        }));
-    } catch (e) {
-        console.error("Put event error", result, e);
-    }
+    await client.send(new PutEventsCommand({
+        Entries: [{
+            EventBusName: process.env.EVENT_BUS,
+            Source: 'monitor',
+            DetailType: "measurement",
+            Detail: JSON.stringify(result)
+        }]
+    }));
 }

--- a/monitor/functions/check-endpoint/handler_test.js
+++ b/monitor/functions/check-endpoint/handler_test.js
@@ -4,6 +4,7 @@ import { PutEventsCommand } from "@aws-sdk/client-eventbridge";
 import { checkEndpoint } from "./handler.js"
 import { MockAgent } from 'undici';
 import { use } from "../../common/fixtures.js";
+import { throwsAsync } from '../../common/assert.js'
 import { UnexpectedRedirectLocationError, UnexpectedHttpStatusError, serializeError } from "../../common/errors.js";
 
 const assertEventBridgePayload = function (events, expected) {
@@ -249,7 +250,7 @@ describe('monitor - checkEndpoint', () => {
         });
     });
 
-    it('should handle EventBridge errors', async (t) => {
+    it('should throw on EventBridge errors', async (t) => {
 
         const service = {
             type: "prefix",
@@ -258,10 +259,9 @@ describe('monitor - checkEndpoint', () => {
             expected_url: "https://poduptime.com/test.mp3"
         };
 
-        const errorLogger = t.mock.method(console, 'error', () => { });
         events.rejects('simulated error');
 
-        await checkEndpoint({ Records: [{ body: JSON.stringify(service) }] }, {
+        await throwsAsync(checkEndpoint({ Records: [{ body: JSON.stringify(service) }] }, {
             agentFactory: (options) => {
 
                 const mockAgent = new MockAgent(options);
@@ -273,8 +273,6 @@ describe('monitor - checkEndpoint', () => {
 
                 return mockAgent;
             }
-        });
-
-        assert.equal(errorLogger.mock.calls.length, 1);
+        }));
     });
 });

--- a/monitor/functions/kickstart/handler.js
+++ b/monitor/functions/kickstart/handler.js
@@ -13,13 +13,9 @@ export const kickstart = async function (event, context) {
             return { Id: randomUUID(), MessageBody: JSON.stringify({ endpoint: endpoint.id, ...service }) }
         });
 
-        try {
-            await client.send(new SendMessageBatchCommand({
-                QueueUrl: process.env.CHECK_QUEUE_URL,
-                Entries: messages
-            }));
-        } catch (err) {
-            console.error("Cannot schedule endpoint check", endpoint, err);
-        }
+        await client.send(new SendMessageBatchCommand({
+            QueueUrl: process.env.CHECK_QUEUE_URL,
+            Entries: messages
+        }));
     }
 }

--- a/monitor/functions/kickstart/handler_test.js
+++ b/monitor/functions/kickstart/handler_test.js
@@ -4,6 +4,7 @@ import { SendMessageBatchCommand } from "@aws-sdk/client-sqs";
 import { kickstart } from "./handler.js"
 import config from "../../conf/config.js";
 import { use } from "../../common/fixtures.js";
+import { throwsAsync } from '../../common/assert.js'
 
 describe('monitor - kickstart', () => {
 
@@ -32,13 +33,10 @@ describe('monitor - kickstart', () => {
         })
     });
 
-    it('should handle SQS errors', async (t) => {
+    it('should throw on SQS errors', async (t) => {
 
-        const errorLogger = t.mock.method(console, 'error', () => { });
         sqs.rejects('simulated error');
 
-        await kickstart();
-
-        assert.equal(errorLogger.mock.calls.length, config.endpoints.length);
+        await throwsAsync(kickstart());
     });
 });

--- a/monitor/serverless.yml
+++ b/monitor/serverless.yml
@@ -53,6 +53,17 @@ resources:
   - ${file(deployment/resources/events.yml)}
 
 functions:
+  #
+  # Function: kickstart
+  # Purpose: start the monitoring process by submitting monitoring
+  #   jobs to an SQS queue
+  # Failure mode: This function is invoked async from EventBridge so its retry
+  #   policy is managed with maximumRetryAttempts/onFailure. In this
+  #   specific case being this function re-triggered every minute from
+  #   a scheduled event, we're NOT going to perform any retry in case
+  #   this function fail and we don't need the initial event to be
+  #   delivered to a DLQ
+  #
   kickstart:
     name: ${self:custom.appPrefix}-kickstart
     handler: functions/kickstart/handler.kickstart
@@ -63,6 +74,16 @@ functions:
           - QueueUrl
     events:
       - schedule: rate(1 minute)
+    maximumRetryAttempts: 0
+  #
+  # Function: checkEndpoint
+  # Purpose: perform a single monitoring job and dispatch the
+  #   resulting status event to EventBridge
+  # Failure mode:  This function is invoked by the Lambda/SQS poller
+  # so its retry policy is managed by the SQS queue configuration. In this
+  # specific case, it's setup to allow for single delivery and then move the
+  # message to a blackhole DLQ that evicts them fast and we'd never redrive.
+  #
   checkEndpoint:
     name: ${self:custom.appPrefix}-checkEndpoint
     handler: functions/check-endpoint/handler.checkEndpoint

--- a/monitor/serverless.yml
+++ b/monitor/serverless.yml
@@ -80,9 +80,9 @@ functions:
   # Purpose: perform a single monitoring job and dispatch the
   #   resulting status event to EventBridge
   # Failure mode:  This function is invoked by the Lambda/SQS poller
-  # so its retry policy is managed by the SQS queue configuration. In this
-  # specific case, it's setup to allow for single delivery and then move the
-  # message to a blackhole DLQ that evicts them fast and we'd never redrive.
+  #   so its retry policy is managed by the SQS queue configuration. In this
+  #   specific case, it's setup to allow for single delivery and then move the
+  #   message to a blackhole DLQ that evicts them fast and we'd never redrive.
   #
   checkEndpoint:
     name: ${self:custom.appPrefix}-checkEndpoint


### PR DESCRIPTION
In this PR I'm doing most of the work for #18. The issue cannot be closed in a single PR because of possible data loss during deployments. Details below.

## Lambda running on a schedule

Every Lambda running on a `1 minute` schedule has been updated to turn off retries and the code has been changed to let exceptions bubble. This will increase the failed invocation metric for Lambda and trigger an alert instead of just producing a log like before. 

Every Lambda running on a `1 day` schedule has been updated to allow for a couple of retries. As for the Lambdas running every minute, I removed the exception handling code so it fails and we can see that through the metrics. 

## Lambda polling SQS

SQS queues have been updated with the appropriate policies to configure retries and DLQs when appropriate. Since in order to turn off retries you need a DLQ even if you're not going to use it, I created a `blackhole` DLQ where messages simply gets deleted after 1 minute.

## Lambda connected to EventBridge

I created SQS queues with a DLQ and connected them to the same event the Lambdas are connected to. A following PR will change the configuration of these Lambdas so they start polling from the queues instead of listening to EventBridge events. The reason why we are inserting queues in between is to have better control over retries since EventBridge calls the Lambda in a fire and forget fashion and if we simply use `onFailure` with a DLQ we'd still need another SQS queues to redrive the DLQ to. I cannot connect the Lambdas to the queues in this PR since I fear there will be data loss during deployment, so another PR will follow to be deployed right after this one. Some messages will be processed twice but both archive Lambda are already able to deal with duplication. 