### PR TITLE
Removed unused parameter

### DIFF
--- a/analytics/serverless.yml
+++ b/analytics/serverless.yml
@@ -86,7 +86,6 @@ custom:
   lambdaSubnetIds: !Split [",", "${param:lambdaSubnetIds}"]
   databaseSubnetIds: !Split [",", "${param:databaseSubnetIds}"]
   administrativeSecurityGroupId: ${param:administrativeSecurityGroupId}
-  observabilityAccountId: ${param:observabilityAccountId}
   observabilityLayerArn: ${param:observabilityLayerArn}
   observabilityQueueArn: ${param:observabilityQueueArn}
   prune:


### PR DESCRIPTION
I realized `observabilityAccountId` is not needed anymore so I'm getting rid of it