### PR TITLE
Fix charts firefox

### DIFF
--- a/website/src/pages/[endpoint].astro
+++ b/website/src/pages/[endpoint].astro
@@ -108,7 +108,8 @@ const endpointServices = MONITORED[endpointId || ''].services
                     'group',
                     'transition-colors',
                     'duration-500',
-                    'relative'
+                    'relative',
+                    'bg-clip-padding'
                   ].join(' ')}
                 >
                   <span
@@ -173,7 +174,8 @@ const endpointServices = MONITORED[endpointId || ''].services
                   'group',
                   'transition-colors',
                   'duration-500',
-                  'relative'
+                  'relative',
+                  'bg-clip-padding'
                 ].join(' ')}
               >
                 <span


### PR DESCRIPTION
Fixed a rendering issue for charts on firefox

BEFORE:
<img width="692" alt="before" src="https://github.com/spreaker/poduptime/assets/49144/9397a746-4b92-448c-b27d-3874fddd7d31">

AFTER
<img width="694" alt="after" src="https://github.com/spreaker/poduptime/assets/49144/6999ddb4-fa91-4122-baf2-e374621fc833">
