### PR TITLE
Removed Megaphone from monitoring

### DIFF
--- a/conf/config_prod.js
+++ b/conf/config_prod.js
@@ -45,17 +45,6 @@ const endpoints = [
     ],
   },
   {
-    id: "megaphone",
-    label: "Megaphone",
-    website_url: "https://megaphone.fm",
-    services: [
-      {
-        type: "enclosure",
-        url: "https://traffic.megaphone.fm/VOXN5992769941.mp3?updated=1696351884",
-      },
-    ],
-  },
-  {
     id: "buzzsprout",
     label: "Buzzsprout",
     website_url: "https://www.buzzsprout.com",

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -12,6 +12,20 @@ import Layout from '../layouts/Layout.astro'
   <h2
     class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
   >
+    May 9th, 2024
+  </h2>
+
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      We removed the following service to our monitoring list: <code>Megaphone</code>. This is due to
+      the RSS feed used for monitoring purpose being not available anymore. We'll be happy to reinstate
+      monitoring for <code>Megaphone</code> if a valid RSS feed is provided.
+    </li>
+  </ul>
+
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
     November 2nd, 2023
   </h2>
 


### PR DESCRIPTION
Our Megaphone test feed is not available anymore so we are removing Megaphone from the list of monitored platform.