### PR TITLE
Use public ECR images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,15 @@
 name: Node.js CI
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 jobs:
   tests:
     runs-on: ubuntu-latest
     services:
       postgresql:
-        image: postgres:15.3-alpine
+        image: public.ecr.aws/docker/library/postgres:15.3-alpine
         env:
           POSTGRES_DB: poduptime
           POSTGRES_USER: lambda
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: "20.x"
       - run: npm ci
         working-directory: ./monitor
       - run: npm ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "4321:4321"
 
   postgresql:
-    image: postgres:15.3-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     environment:
       POSTGRES_DB: poduptime
       POSTGRES_USER: lambda


### PR DESCRIPTION
We moved from docker hub to AWS public ecr images since on the 1st of april docker hub registry will limit the number of pull/push per hour.

![Screenshot 2025-03-04 alle 14 24 25](https://github.com/user-attachments/assets/90b10321-183d-4a99-9c59-fb353c0d4139)
