### PR TITLE
Add client side CORS check for prefix services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+PodUptime is a distributed uptime monitoring system for the podcast industry (built/maintained by Spreaker). It measures availability of podcast hosting platforms and tracking prefixes from multiple AWS regions. Full architecture description: `README.md` and `doc/architecture.excalidraw.svg`.
+
+The repo has three independently deployed components plus shared config:
+
+- **`monitor/`** — multi-region measurement system. A scheduled `kickstart` Lambda pushes one job per monitored service to SQS every minute; a `check-endpoint` Lambda consumes the queue, performs the HTTP check, and publishes a `measurement` event to EventBridge.
+- **`analytics/`** — ingests measurement events (fanned out from all monitor regions to one central EventBridge bus), stores raw data in S3 (Athena-friendly) and structured data in Aurora Serverless Postgres, and runs scheduled aggregation/retention Lambdas whose output (JSON files in S3) is the data source for the website.
+- **`website/`** — static Astro + Tailwind site reading the aggregated JSON from S3/CloudFront, deployed as a static site.
+- **`conf/`** — configuration shared between `monitor`, `analytics`, and `website` (endpoints/services to monitor, regions, etc.), isomorphic between Node and browser (see `conf/config.js`).
+
+`monitor`, `analytics`, and `website` each have their own `package.json`, `package-lock.json`, and `serverless.yml`, and are deployed independently. `serverless.yml` files reference `${param.SOMETHING}` values injected at deploy time by tooling outside this repo — they won't run standalone.
+
+## Commands
+
+Local dev happens inside a Docker container that also runs a Postgres sidecar (schema auto-loaded on start):
+
+```shell
+docker compose build dev && docker compose run --rm dev sh
+```
+
+Run tests (root-level `node --test`, covers `monitor`, `analytics`, and root `conf_test.js`; requires the Postgres sidecar/env vars, see `.github/workflows/tests.yml` for the exact env vars used in CI):
+
+```shell
+npm run test
+npm run test-watch   # watch mode
+```
+
+Run a single test file directly with the native runner, e.g.:
+
+```shell
+node --test monitor/functions/check-endpoint/handler_test.js
+```
+
+Run the website locally against real `poduptime.com` data/config:
+
+```shell
+cd website
+npm install
+STAGE=prod PUBLIC_STAGE=prod npm run dev -- --host
+```
+
+`STAGE`/`PUBLIC_STAGE` select `conf/config_${STAGE}.js` (`STAGE` drives Astro's server-side generation, `PUBLIC_STAGE` drives client-side JS — always set both to the same value).
+
+## Architecture notes
+
+- Everything is ESM (`"type": "module"` everywhere); Lambda handlers are plain exported async functions (e.g. `export const checkEndpoint = async (event, context) => {...}`).
+- `monitor/functions/check-endpoint/handler.js` creates/destroys a dedicated `undici` `Agent` per measurement (rather than reusing the global agent) so that keep-alive connection reuse only happens within a single redirect chain, not across separate measurements. Prefix-type services are checked with `maxRedirections: 0` and must return a 3xx redirecting to the configured `expected_url`; other service types must return `200`.
+- Dependency injection for testability: handlers accept things like `agentFactory` via the Lambda `context` object (see `context?.agentFactory ?? createAgent` in `check-endpoint/handler.js`) so tests can substitute fakes without mocking modules.
+- `analytics/common/database.js` manages a lazily-created `pg` `Pool` authenticated via IAM/RDS `Signer` tokens (short-lived, refreshed based on `EXPIRE_TOLERANCE`/`TOKEN_LIFETIME`); set `PGPASSWORD` to bypass IAM auth for local/test Postgres. TLS is only enabled when `AWS_EXECUTION_ENV` is set (i.e., running in real Lambda).
+- `analytics/deployment/database/schema.sql` defines two tables: `measurements` (all results, aggregated later) and `unavailables` (raw failure details kept short-term for troubleshooting).
+- Adding a new endpoint/service to monitor requires: (1) an entry in `conf/config_${STAGE}.js` (prefix services need `expected_url`), (2) if it's a prefix endpoint, a new `<item>` in `website/public/rss/feed.xml` so prefix services can validate against a real feed, and (3) a changelog entry in `website/src/pages/changelog.astro`.
+- `conf/config.js` picks `config_prod.js` vs `config_nonprod.js` based on `STAGE`/`PUBLIC_STAGE` env vars, and is written to work both under Node (`process.env`) and in the browser (`import.meta.env`) — keep that dual-environment compatibility in mind when editing it.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Data retention is managed differently for the two storage systems:
 
 The primary purpose of the `website` component is to offer a user interface for visualizing the data collected by the `monitor` and `analytics` components. It serves as a static website, constructed with [Astro](https://astro.build) and styled with [Tailwind CSS](https://tailwindcss.com/). Deployment involves hosting the website on `S3` and delivering it via a `CloudFront` distribution. This setup ensures efficient and scalable delivery of the user interface to end-users.
 
-Each `prefix` service on an endpoint's detail page also offers an on-demand, browser-side `CORS` check, surfacing a signal that's complementary to the server-side `HTTP HEAD` uptime measurements and relevant to in-browser playback technologies such as `HLS`.
+Each `prefix` service on an endpoint's detail page also runs an automatic, browser-side `CORS` check on page load, surfacing a signal that's complementary to the server-side `HTTP HEAD` uptime measurements and relevant to in-browser playback technologies such as `HLS`.
 
 ## Technology Choices
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Data retention is managed differently for the two storage systems:
 
 The primary purpose of the `website` component is to offer a user interface for visualizing the data collected by the `monitor` and `analytics` components. It serves as a static website, constructed with [Astro](https://astro.build) and styled with [Tailwind CSS](https://tailwindcss.com/). Deployment involves hosting the website on `S3` and delivering it via a `CloudFront` distribution. This setup ensures efficient and scalable delivery of the user interface to end-users.
 
+Each `prefix` service on an endpoint's detail page also offers an on-demand, browser-side `CORS` check, surfacing a signal that's complementary to the server-side `HTTP HEAD` uptime measurements and relevant to in-browser playback technologies such as `HLS`.
+
 ## Technology Choices
 
 At Spreaker, side projects serve as a means to have fun and explore technologies we are not yet familiar with. PodUptime is no exception and embraces a blend of foundational technologies that are part of our standard toolset (`S3`, `Lambda`, `CloudFront`, `Serverless Framework`) alongside technologies we are eager to experiment with and learn more about. Some of these include:

--- a/website/src/components/Status.astro
+++ b/website/src/components/Status.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  type: 'UP' | 'DOWN' | 'PARTIAL' | 'UNKNOWN' | 'LOADING'
+  type: 'UP' | 'DOWN' | 'PARTIAL' | 'UNKNOWN' | 'LOADING' | 'CORS_OK' | 'CORS_KO'
 }
 
 const { type } = Astro.props
@@ -10,7 +10,9 @@ const text = {
   DOWN: 'DOWN',
   PARTIAL: 'PARTIAL',
   UNKNOWN: 'UNKNOWN',
-  LOADING: '...'
+  LOADING: '...', 
+  CORS_OK: 'CORS OK',
+  CORS_KO: 'CORS KO',
 }
 
 const base = [
@@ -28,7 +30,9 @@ const status = {
   DOWN: ['text-red-300', 'border-red-600', 'hover:border-red-300'],
   PARTIAL: ['text-yellow-300', 'border-yellow-600', 'hover:border-yellow-300'],
   UNKNOWN: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300'],
-  LOADING: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300']
+  LOADING: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300'],
+  CORS_OK: ['text-lime-300', 'border-lime-600', 'hover:border-lime-300'],
+  CORS_KO: ['text-red-300', 'border-red-600', 'hover:border-red-300'],
 }
 ---
 

--- a/website/src/lib/Cors.ts
+++ b/website/src/lib/Cors.ts
@@ -1,0 +1,31 @@
+import { CorsCheckResult } from '../types'
+
+const TIMEOUT_MS = 10000
+
+export async function checkCors(type: string, url: string): Promise<CorsCheckResult> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  try {
+    const response = await fetch(url, {
+      method: 'HEAD',
+      mode: 'cors',
+      cache: 'no-store',
+      credentials: 'omit',
+      redirect: 'follow',
+      signal: controller.signal
+    })
+
+    // If we got here, the browser already validated CORS across any
+    // redirect chain — no need to inspect Access-Control-Allow-Origin ourselves.
+    return {
+      type,
+      url,
+      status: 'CORS_OK'
+    }
+  } catch (e) {
+    return { type, url, status: 'CORS_KO' }
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/website/src/lib/Ui.ts
+++ b/website/src/lib/Ui.ts
@@ -18,14 +18,12 @@ const STATUS_BADGE_LABELS = {
 }
 
 const CORS_BADGE_CLASSES = {
-  IDLE: ['text-pink-200', 'border-pink-200', 'hover:border-pink-100', 'hover:text-pink-100'],
   CORS_OK: ['text-lime-300', 'border-lime-600', 'hover:border-lime-300'],
   CORS_KO: ['text-red-300', 'border-red-600', 'hover:border-red-300'],
   PENDING: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300']
 }
 
 const CORS_BADGE_LABELS = {
-  IDLE: 'Run CORS check',
   CORS_OK: 'CORS OK',
   CORS_KO: 'CORS KO',
   PENDING: '...'
@@ -95,7 +93,6 @@ function setCorsBadgeState(
 ) {
   if (!element) return
   element.classList.remove(
-    ...CORS_BADGE_CLASSES.IDLE,
     ...CORS_BADGE_CLASSES.CORS_OK,
     ...CORS_BADGE_CLASSES.CORS_KO,
     ...CORS_BADGE_CLASSES.PENDING

--- a/website/src/lib/Ui.ts
+++ b/website/src/lib/Ui.ts
@@ -1,4 +1,4 @@
-import { Detail, Instant, Issue, ServiceInstant } from '../types'
+import { CorsCheckResult, Detail, Instant, Issue, ServiceInstant } from '../types'
 import { HOSTING, PREFIXES, SERVICE_TYPES } from './Constants'
 
 const STATUS_BADGE_CLASSES = {
@@ -15,6 +15,20 @@ const STATUS_BADGE_LABELS = {
   PARTIAL: 'PARTIAL',
   UNKNOWN: 'UNKNOWN',
   LOADING: '...'
+}
+
+const CORS_BADGE_CLASSES = {
+  IDLE: ['text-pink-200', 'border-pink-200', 'hover:border-pink-100', 'hover:text-pink-100'],
+  CORS_OK: ['text-lime-300', 'border-lime-600', 'hover:border-lime-300'],
+  CORS_KO: ['text-red-300', 'border-red-600', 'hover:border-red-300'],
+  PENDING: ['text-gray-300', 'border-gray-600', 'hover:border-gray-300']
+}
+
+const CORS_BADGE_LABELS = {
+  IDLE: 'Run CORS check',
+  CORS_OK: 'CORS OK',
+  CORS_KO: 'CORS KO',
+  PENDING: '...'
 }
 
 const DETAIL_CELL_CLASSES = {
@@ -73,6 +87,30 @@ export function updateServiceStatusBadges(endpoint: string, data: ServiceInstant
       instant.available
     )
   })
+}
+
+function setCorsBadgeState(
+  element: HTMLElement | undefined | null,
+  status: keyof typeof CORS_BADGE_CLASSES
+) {
+  if (!element) return
+  element.classList.remove(
+    ...CORS_BADGE_CLASSES.IDLE,
+    ...CORS_BADGE_CLASSES.CORS_OK,
+    ...CORS_BADGE_CLASSES.CORS_KO,
+    ...CORS_BADGE_CLASSES.PENDING
+  )
+  element.classList.add(...CORS_BADGE_CLASSES[status])
+  element.innerText = CORS_BADGE_LABELS[status]
+}
+
+export function setCorsBadgePending(endpoint: string, type: string) {
+  setCorsBadgeState(document.getElementById(`cors-badge-${endpoint}-${type}`), 'PENDING')
+}
+
+export function updateCorsBadge(endpoint: string, result: CorsCheckResult) {
+  const element = document.getElementById(`cors-badge-${endpoint}-${result.type}`)
+  setCorsBadgeState(element, result.status)
 }
 
 export function updateStatusBadges(data: Instant[]) {

--- a/website/src/pages/[endpoint].astro
+++ b/website/src/pages/[endpoint].astro
@@ -30,10 +30,16 @@ const endpointId = Astro.params.endpoint
 const endpointLabel = MONITORED[endpointId || ''].label
 const endpointWebsiteUrl = MONITORED[endpointId || ''].website_url
 const endpointServices = MONITORED[endpointId || ''].services
+const hasPrefixService = endpointServices.some((service) => service.type === 'prefix')
 ---
 
 <Layout title={`PodUptime | ${endpointLabel}`} headerLink="/">
-  <div id="data" data-vars={JSON.stringify({ id: endpointId })}></div>
+  <div
+    id="data"
+    data-vars={JSON.stringify({ id: endpointId })}
+    data-services={JSON.stringify(endpointServices)}
+  >
+  </div>
   <div class="flex flex-col items-start sm:flex-row sm:items-center">
     <h1 class="flex-grow text-4xl font-bold text-pink-100">{endpointLabel}</h1>
     <select
@@ -62,17 +68,41 @@ const endpointServices = MONITORED[endpointId || ''].services
     <span class="text-xs">last 30 minutes</span>
   </div>
   <div class="pt-4">
-    <p class="pb-2 text-xs font-bold">Monitored URL(s):</p>
+    <div class="flex items-center justify-between pb-2">
+      <p class="text-xs font-bold">Monitored URL(s):</p>
+      <div class="flex shrink-0 items-center gap-2 text-xs font-bold">
+        {
+          hasPrefixService && (
+            <span class="inline-block w-32 text-right">
+              CORS <a class="underline" href="/about/#cors">(?)</a>
+            </span>
+          )
+        }
+      </div>
+    </div>
     {
       endpointServices.map((service) => {
+        const checksCors = service.type === 'prefix'
         return (
           <div class="flex items-center justify-between pb-2">
             <code class="break-all pr-2 text-xs">{service.url}</code>
-            <div
-              id={`status-badge-${endpointId}-${service.type}`}
-              class="inline-block w-24 shrink-0 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
-            >
-              ...
+            <div class="flex shrink-0 items-center gap-2">
+              <div
+                title="Server-side HTTP status, measured from multiple AWS regions"
+                id={`status-badge-${endpointId}-${service.type}`}
+                class="inline-block w-24 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
+              >
+                ...
+              </div>
+              {checksCors && (
+                <button
+                  title="Runs a live CORS check against this URL, from your own browser"
+                  id={`cors-badge-${endpointId}-${service.type}`}
+                  class="inline-block w-24 rounded border-2 border-pink-200 px-2 py-1 text-center text-xs font-bold text-pink-200 hover:border-pink-100 hover:text-pink-100"
+                >
+                  Check CORS
+                </button>
+              )}
             </div>
           </div>
         )
@@ -224,15 +254,19 @@ const endpointServices = MONITORED[endpointId || ''].services
 
 <script>
   import { fetchDetailedAndServiceInstantsAndRecentIssuesData } from '../lib/Api'
+  import { checkCors } from '../lib/Cors'
   import {
     updateDetailedGrid,
     updateServiceStatusBadges,
     updateRecentIssues,
-    updateDailyGrid
+    updateDailyGrid,
+    updateCorsBadge,
+    setCorsBadgePending
   } from '../lib/Ui'
 
   const vars = JSON.parse(document.getElementById('data')?.dataset.vars || '{}')
   const endpointId = vars.id || ''
+  const endpointServices = JSON.parse(document.getElementById('data')?.dataset.services || '[]')
 
   document.getElementById('region')?.addEventListener('change', async (event) => {
     const region = (event.target as HTMLSelectElement).value
@@ -256,4 +290,22 @@ const endpointServices = MONITORED[endpointId || ''].services
   updateServiceStatusBadges(endpointId, instants)
   updateRecentIssues(issues)
   updateDailyGrid(daily)
+
+  // The CORS check is a live, browser-side probe against a third-party URL, so it
+  // only runs when explicitly requested, and only for prefix services (redirects
+  // followed by the browser, relevant to in-browser playback, e.g. via HLS/hls.js).
+  endpointServices
+    .filter((service: { type: string }) => service.type === 'prefix')
+    .forEach((service: { type: string; url: string }) => {
+      document
+        .getElementById(`cors-badge-${endpointId}-${service.type}`)
+        ?.addEventListener('click', async (event) => {
+          const button = event.currentTarget as HTMLButtonElement
+          button.disabled = true
+          setCorsBadgePending(endpointId, service.type)
+          const result = await checkCors(service.type, service.url)
+          updateCorsBadge(endpointId, result)
+          button.disabled = false
+        })
+    })
 </script>

--- a/website/src/pages/[endpoint].astro
+++ b/website/src/pages/[endpoint].astro
@@ -95,13 +95,13 @@ const hasPrefixService = endpointServices.some((service) => service.type === 'pr
                 ...
               </div>
               {checksCors && (
-                <button
-                  title="Runs a live CORS check against this URL, from your own browser"
+                <div
+                  title="Live CORS check against this URL, performed automatically from your own browser"
                   id={`cors-badge-${endpointId}-${service.type}`}
-                  class="inline-block w-24 rounded border-2 border-pink-200 px-2 py-1 text-center text-xs font-bold text-pink-200 hover:border-pink-100 hover:text-pink-100"
+                  class="inline-block w-24 rounded border-2 border-gray-600 px-2 py-1 text-center text-xs font-bold text-gray-300"
                 >
-                  Check CORS
-                </button>
+                  ...
+                </div>
               )}
             </div>
           </div>
@@ -291,21 +291,14 @@ const hasPrefixService = endpointServices.some((service) => service.type === 'pr
   updateRecentIssues(issues)
   updateDailyGrid(daily)
 
-  // The CORS check is a live, browser-side probe against a third-party URL, so it
-  // only runs when explicitly requested, and only for prefix services (redirects
-  // followed by the browser, relevant to in-browser playback, e.g. via HLS/hls.js).
+  // The CORS check is a live, browser-side probe against a third-party URL, run
+  // automatically on page load, and only for prefix services (redirects followed
+  // by the browser, relevant to in-browser playback, e.g. via HLS/hls.js).
   endpointServices
     .filter((service: { type: string }) => service.type === 'prefix')
-    .forEach((service: { type: string; url: string }) => {
-      document
-        .getElementById(`cors-badge-${endpointId}-${service.type}`)
-        ?.addEventListener('click', async (event) => {
-          const button = event.currentTarget as HTMLButtonElement
-          button.disabled = true
-          setCorsBadgePending(endpointId, service.type)
-          const result = await checkCors(service.type, service.url)
-          updateCorsBadge(endpointId, result)
-          button.disabled = false
-        })
+    .forEach(async (service: { type: string; url: string }) => {
+      setCorsBadgePending(endpointId, service.type)
+      const result = await checkCors(service.type, service.url)
+      updateCorsBadge(endpointId, result)
     })
 </script>

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -123,6 +123,41 @@ import Layout from '../layouts/Layout.astro'
   </p>
 
   <h2
+    id="cors"
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
+    What is the check CORS button for prefix services?
+  </h2>
+
+  <p class="mb-4 [&>code]:underline">
+    Our server-side <code>HTTP HEAD</code> measurements are performed by a Lambda function, not a
+    browser, so they never trigger <code>CORS</code>. However, in-browser playback technologies
+    such as <code>HLS</code> (commonly implemented via <code>hls.js</code>) fetch media segments
+    using cross-origin <code>fetch</code>/<code>XHR</code> requests, which do require the target
+    server to respond with proper <code>Access-Control-Allow-Origin</code> headers, unlike a plain
+    <code>&lt;audio&gt;</code>/<code>&lt;video&gt;</code> tag.
+  </p>
+  <p>The &nbsp;&nbsp;<button class="inline-block w-24 rounded border-2 border-pink-200 px-2 py-1 text-center text-xs font-bold text-pink-200 hover:border-pink-100 hover:text-pink-100">Check CORS</button>&nbsp;&nbsp; button surfaces this complementary, browser-only signal by performing a live check, directly
+    from your own browser, against a <code>prefix</code> service's <code>URL</code> on an endpoint's
+    detail page resulting in either a &nbsp;&nbsp;<Status type="CORS_OK" />&nbsp;&nbsp; or &nbsp;&nbsp;<Status type="CORS_KO" />&nbsp;&nbsp; status.
+  </p>
+
+  <p class="mb-4 [&>code]:underline">
+    This check is only available for <code>prefix</code> services. We intentionally leave <code
+      >enclosure</code
+    > URLs out of scope: anyone shipping HLS video already has to satisfy Apple's own requirements
+    around <code>CORS</code>, so there's little value in re-verifying it here.
+  </p>
+
+  <p class="mb-4 [&>code]:underline">
+    Under the hood, the check performs an <code>HTTP HEAD</code> request from your browser and
+    confirms that the full redirect chain completes successfully. We don't surface the response
+    headers themselves, since depending on the browser and the server's <code
+      >Access-Control-Expose-Headers</code
+    > configuration, they may not actually be made available to JavaScript.
+  </p>
+
+  <h2
     class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
   >
     Why is a particular hosting platform / prefix missing?

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -126,7 +126,7 @@ import Layout from '../layouts/Layout.astro'
     id="cors"
     class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
   >
-    What is the check CORS button for prefix services?
+    What is the CORS status for prefix services?
   </h2>
 
   <p class="mb-4 [&>code]:underline">
@@ -137,9 +137,12 @@ import Layout from '../layouts/Layout.astro'
     server to respond with proper <code>Access-Control-Allow-Origin</code> headers, unlike a plain
     <code>&lt;audio&gt;</code>/<code>&lt;video&gt;</code> tag.
   </p>
-  <p>The &nbsp;&nbsp;<button class="inline-block w-24 rounded border-2 border-pink-200 px-2 py-1 text-center text-xs font-bold text-pink-200 hover:border-pink-100 hover:text-pink-100">Check CORS</button>&nbsp;&nbsp; button surfaces this complementary, browser-only signal by performing a live check, directly
-    from your own browser, against a <code>prefix</code> service's <code>URL</code> on an endpoint's
-    detail page resulting in either a &nbsp;&nbsp;<Status type="CORS_OK" />&nbsp;&nbsp; or &nbsp;&nbsp;<Status type="CORS_KO" />&nbsp;&nbsp; status.
+  <p class="mb-4">
+    This complementary, browser-only signal is surfaced automatically, as soon as an endpoint's
+    detail page loads, by performing a live check directly from your own browser against a <code
+      >prefix</code
+    > service's <code>URL</code>, resulting in either a &nbsp;&nbsp;<Status type="CORS_OK" />&nbsp;&nbsp;
+    or &nbsp;&nbsp;<Status type="CORS_KO" />&nbsp;&nbsp; status.
   </p>
 
   <p class="mb-4 [&>code]:underline">

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -12,6 +12,26 @@ import Layout from '../layouts/Layout.astro'
   <h2
     class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
   >
+    July 3rd, 2026
+  </h2>
+
+  <ul class="mb-4 list-outside list-disc pl-4">
+    <li class="pb-3 [&>code]:underline">
+      Each <code>prefix</code> service on an endpoint's detail page now includes a <code
+        >Run CORS check</code
+      > button, next to its <code>HTTP</code> status, which performs a live, browser-side cross-origin
+      <code>HTTP HEAD</code> request against that URL. This is a browser-side signal, distinct from our
+      server-side <code>HTTP HEAD</code> uptime checks, meant to help identify prefixes that may not be
+      compatible with in-browser playback technologies such as <code>HLS</code> (via <code>hls.js</code
+      >), which require proper <code>Access-Control-Allow-Origin</code> headers unlike a plain <code
+        >&lt;audio&gt;</code
+      >/<code>&lt;video&gt;</code> tag.
+    </li>
+  </ul>
+
+  <h2
+    class="mb-4 mt-6 border-b-2 border-dotted border-pink-100 pb-2 text-2xl font-bold text-pink-100"
+  >
     September 10th, 2025
   </h2>
 

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -17,12 +17,12 @@ import Layout from '../layouts/Layout.astro'
 
   <ul class="mb-4 list-outside list-disc pl-4">
     <li class="pb-3 [&>code]:underline">
-      Each <code>prefix</code> service on an endpoint's detail page now includes a <code
-        >Run CORS check</code
-      > button, next to its <code>HTTP</code> status, which performs a live, browser-side cross-origin
-      <code>HTTP HEAD</code> request against that URL. This is a browser-side signal, distinct from our
-      server-side <code>HTTP HEAD</code> uptime checks, meant to help identify prefixes that may not be
-      compatible with in-browser playback technologies such as <code>HLS</code> (via <code>hls.js</code
+      Each <code>prefix</code> service on an endpoint's detail page now automatically runs a live,
+      browser-side cross-origin <code>HTTP HEAD</code> request against that URL as soon as the page
+      loads, surfacing the result next to its <code>HTTP</code> status. This is a browser-side signal,
+      distinct from our server-side <code>HTTP HEAD</code> uptime checks, meant to help identify prefixes
+      that may not be compatible with in-browser playback technologies such as <code>HLS</code> (via <code
+        >hls.js</code
       >), which require proper <code>Access-Control-Allow-Origin</code> headers unlike a plain <code
         >&lt;audio&gt;</code
       >/<code>&lt;video&gt;</code> tag.

--- a/website/src/types.d.ts
+++ b/website/src/types.d.ts
@@ -18,7 +18,7 @@ export type Detail = {
   available: number | null
 }
 
-export type CorsCheckStatus = 'IDLE' | 'PENDING' | 'CORS_OK' | 'CORS_KO'
+export type CorsCheckStatus = 'PENDING' | 'CORS_OK' | 'CORS_KO'
 
 export type CorsCheckResult = {
   type: string

--- a/website/src/types.d.ts
+++ b/website/src/types.d.ts
@@ -18,6 +18,14 @@ export type Detail = {
   available: number | null
 }
 
+export type CorsCheckStatus = 'IDLE' | 'PENDING' | 'CORS_OK' | 'CORS_KO'
+
+export type CorsCheckResult = {
+  type: string
+  url: string
+  status: CorsCheckStatus
+}
+
 export type Issue = {
   id: string
   timestamp: string


### PR DESCRIPTION
Our server-side HTTP HEAD measurements are performed by a Lambda function, not a browser, so they never trigger CORS. However, in-browser playback technologies such as HLS (commonly implemented via hls.js) fetch media segments using cross-origin fetch/XHR requests, which do require the target server to respond with proper Access-Control-Allow-Origin headers, unlike a plain `<audio>/<video>` tag.

This complementary, browser-only signal is surfaced automatically, as soon as an endpoint's detail page loads, by performing a live check directly from your own browser against a prefix service's URL, resulting in either a:
- CORS OK
- CORS KO

This check is only available for prefix services. We intentionally leave enclosure URLs out of scope: anyone shipping HLS video already has to satisfy Apple's own requirements around CORS, so there's little value in re-verifying it here.

Under the hood, the check performs an HTTP HEAD request from your browser and confirms that the full redirect chain completes successfully. We don't surface the response headers themselves, since depending on the browser and the server's Access-Control-Expose-Headers configuration, they may not actually be made available to JavaScript.

<img width="701" height="308" alt="Screenshot 2026-07-03 alle 14 28 55" src="https://github.com/user-attachments/assets/d0a5cdba-ddde-4a12-8824-2900c3755761" />
<img width="703" height="296" alt="Screenshot 2026-07-03 alle 14 28 46" src="https://github.com/user-attachments/assets/5d5838e3-e34a-441f-872c-7a16915b45fe" />
